### PR TITLE
Add root README pointing to the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # .github
+
+Organization-level configuration and the public website for the
+[Modern Python](https://github.com/modern-python) GitHub organization.
+
+- **Website:** [modern-python.org](https://modern-python.org) — built from `docs/`
+  with MkDocs + Material and deployed to GitHub Pages via
+  [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) on every push to `main`.
+- **Org profile:** [`profile/README.md`](profile/README.md) renders on the
+  organization's GitHub landing page.
+- **Deployment & domain setup:** see [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
+
+## Local development
+
+```bash
+uv run mkdocs serve
+```


### PR DESCRIPTION
## Summary

Replaces the placeholder root `README.md` (`# .github`) with a short overview linking to:
- the live site, **modern-python.org**
- the org profile (`profile/README.md`)
- the deployment runbook (`docs/DEPLOYMENT.md`)

Plus a one-line local-dev command (`uv run mkdocs serve`).

## Test Plan
- [x] Markdown links resolve to existing paths/URLs
- [x] No build/site impact (root README is not part of the MkDocs `docs/` tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)