### PR TITLE
Bump deploy actions to Node 24 versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,15 +18,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.11"
       - name: Build site
         run: uv run mkdocs build --strict
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -39,4 +39,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Updates the Pages deploy workflow actions to their latest majors, clearing the GitHub deprecation warning that Node 20 actions are forced to Node 24 starting 2026-06-16 (and removed 2026-09-16).

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| astral-sh/setup-uv | v6 | v8 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

`upload-pages-artifact` and `deploy-pages` are bumped together (versioned as a pair by the Pages team).

## Test Plan
- [x] Workflow YAML parses
- [ ] On merge: the **Deploy site** run succeeds with no Node 20 deprecation annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)