### PR TITLE
Fix: use setup-uv@v7 (v8 tag does not resolve)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
       - name: Build site


### PR DESCRIPTION
## Summary

PR #4 bumped `astral-sh/setup-uv` to `@v8`, which broke the deploy: setup-uv publishes a moving major tag only through `v7` — the v8 line has exact tags (`v8.0.0`/`v8.1.0`/`v8.2.0`) only — so `@v8` failed to resolve at job setup.

Switches to `@v7`, which:
- runs on **Node 24** (confirmed `using: "node24"` in its `action.yml`), so it still clears the deprecation warning, and
- is a moving major tag, so it floats to patch releases automatically.

The other three actions (`checkout@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`) publish moving major tags and resolved fine.

## Test Plan
- [x] Workflow YAML parses
- [x] `setup-uv@v7` exists and runs on Node 24
- [ ] On merge: **Deploy site** run succeeds with no Node 20 annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)