### PR TITLE
Fix dark-mode link contrast

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -12,6 +12,9 @@
   --md-primary-fg-color--light: #4a8a6e;
   --md-primary-fg-color--dark:  #234738;
   --md-accent-fg-color:         #e0a300;
+  /* Body links default to the primary green, which is too dark on the dark
+     background — use a lighter green (AA-contrast) for readability. */
+  --md-typeset-a-color:         #7fb79f;
 }
 
 /* Centered hero intro on the homepage */


### PR DESCRIPTION
## Summary

Body links (project repo links, tagline) were the dark brand green `#356852`, which Material derives from the primary color — too low-contrast on the dark (slate) background to read comfortably.

Overrides `--md-typeset-a-color` in the dark scheme with a lighter green (`#7fb79f`, ~5.9:1 contrast on the slate background, passes WCAG AA). Light mode is unchanged.

## Test Plan
- [x] `uv run mkdocs build --strict` exits 0
- [x] `--md-typeset-a-color: #7fb79f` present in the built slate CSS
- [x] homepage content check green
- [ ] after deploy: toggle dark mode and confirm links are legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)