### PR TITLE
Richer Open Graph metadata + robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://modern-python.org/sitemap.xml

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,13 +1,30 @@
 {% extends "base.html" %}
 
-{#- Static social card (Open Graph / Twitter) for modern-python.org. -#}
+{#- Open Graph / Twitter card metadata for modern-python.org. -#}
 {% block extrahead %}
   {{ super() }}
   {% set card = config.site_url ~ "assets/social-card.png" %}
+  {%- if page.meta and page.meta.title %}
+    {%- set title = page.meta.title %}
+  {%- elif page.is_homepage %}
+    {%- set title = config.site_name %}
+  {%- elif page.title %}
+    {%- set title = page.title ~ " · " ~ config.site_name %}
+  {%- else %}
+    {%- set title = config.site_name %}
+  {%- endif %}
+  {% set description = page.meta.description if page.meta and page.meta.description else config.site_description %}
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ description }}">
+  <meta property="og:url" content="{{ page.canonical_url }}">
   <meta property="og:image" content="{{ card }}">
   <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ description }}">
   <meta name="twitter:image" content="{{ card }}">
 {% endblock %}


### PR DESCRIPTION
## Summary

Two of the requested niceties (the third, IPv6, is a registrar-side DNS issue — see note below).

**Open Graph / Twitter metadata** — Material was only emitting the `og:image`/`twitter:image` tags we added; there was no `og:type`, `og:site_name`, `og:title`, `og:description`, or `og:url`. Adds the full set in `overrides/main.html`:
- `og:type=website`, `og:site_name`, `og:title`, `og:description`, `og:url`, plus `twitter:title`/`twitter:description`.
- Title logic: site name on the homepage (instead of the "Home" nav label), `"<page> · Modern Python"` on future sub-pages, with `page.meta.title` taking precedence.

**robots.txt** — adds `docs/robots.txt` (allow all) pointing at `https://modern-python.org/sitemap.xml`. MkDocs already generates the sitemap; there was no robots.txt before.

## Note: IPv6 / AAAA
Rechecked via both Google and Cloudflare resolvers — the apex `AAAA` records still return nothing (A records and `www` are fine). The records don't appear to be live at the registrar; worth re-verifying the four `AAAA` host/value entries. Not fixable from this repo.

## Test Plan
- [x] `uv run mkdocs build --strict` exits 0
- [x] built `index.html` has og:type/site_name/title/description/url + twitter title/description; title = "Modern Python"
- [x] `site/robots.txt` present and references the sitemap
- [x] homepage content check green
- [ ] after deploy: re-run a card debugger to see the richer preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)