### PR TITLE
chore: add org-wide community-health defaults

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a defect in a modern-python project
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Fill in the sections below so we can reproduce it quickly.
+  - type: input
+    id: project
+    attributes:
+      label: Affected project
+      description: Which repository / package is this about?
+      placeholder: e.g. modern-di, that-depends, httpware
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Versions
+      description: Package version, Python version, and OS.
+      placeholder: e.g. modern-di 1.2.0, Python 3.12, macOS 14
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: The smallest snippet or steps that reproduce the problem.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      description: Paste any relevant traceback. Automatically formatted as code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / usage help
+    url: https://github.com/orgs/modern-python/discussions
+    about: Ask questions and get help in GitHub Discussions.
+  - name: Documentation
+    url: https://modern-python.org
+    about: Browse the docs — your question may already be answered.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an idea or improvement for a modern-python project
+labels: ["enhancement"]
+body:
+  - type: input
+    id: project
+    attributes:
+      label: Target project
+      description: Which repository / package would this affect?
+      placeholder: e.g. modern-di, lite-bootstrap
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? Include API sketches if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've weighed, if any.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,6 @@
 - [ ] Lint and format pass (`ruff`)
 - [ ] Type check passes (`ty`)
 - [ ] Tests pass and new behavior is covered
+- [ ] Build succeeds (`uv build`) if packaging or build config changed
 - [ ] Docs updated if behavior or public API changed
 - [ ] Repo metadata stays consistent across the three surfaces (GitHub description, pyproject `description`, profile blurb) if this touches packaging

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What does this change and why? Link any related issue: Closes #123 -->
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+-
+
+## Checklist
+
+- [ ] Lint and format pass (`ruff`)
+- [ ] Type check passes (`ty`)
+- [ ] Tests pass and new behavior is covered
+- [ ] Docs updated if behavior or public API changed
+- [ ] Repo metadata stays consistent across the three surfaces (GitHub description, pyproject `description`, profile blurb) if this touches packaging

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through GitHub's
+private reporting (open the relevant repository's **Security** tab and choose
+**Report a vulnerability**, which routes confidentially to the maintainers) or
+by privately contacting a maintainer. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,11 +59,9 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement through GitHub's
-private reporting (open the relevant repository's **Security** tab and choose
-**Report a vulnerability**, which routes confidentially to the maintainers) or
-by privately contacting a maintainer. All complaints will be reviewed and
-investigated promptly and fairly.
+reported to the community leaders responsible for enforcement at
+krenix@yandex.ru.
+All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ just --list             # see available tasks (lint, test, etc.) where a justfil
 3. Run lint, type check, and tests locally before pushing:
    ```bash
    uv run ruff check . && uv run ruff format --check .
-   uv run ty check
+   uv run ty check        # type check, where ty is configured (some repos also run mypy/pyrefly)
    # run the project's test command (often `just test` or `uv run pytest`)
    ```
 4. Update docs if you changed behavior or public API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Modern Python
+
+Thanks for your interest in contributing! These guidelines apply across all
+repositories in the [`modern-python`](https://github.com/modern-python) org
+unless a repository overrides them with its own `CONTRIBUTING.md`.
+
+## Ways to contribute
+
+- **Report bugs** and **request features** via the issue templates.
+- **Ask questions** in [GitHub Discussions](https://github.com/orgs/modern-python/discussions).
+- **Improve docs** — typo fixes and clarifications are very welcome.
+- **Send pull requests** — see the workflow below.
+
+## Development setup
+
+Projects use [`uv`](https://github.com/astral-sh/uv) for packaging,
+[`ruff`](https://github.com/astral-sh/ruff) for lint/format,
+[`ty`](https://github.com/astral-sh/ty) for type checking, and `uv_build` as the
+build backend. Most repos expose tasks behind a `justfile`.
+
+```bash
+# Clone your fork, then from the repo root:
+uv sync                 # install dependencies into a local venv
+just --list             # see available tasks (lint, test, etc.) where a justfile exists
+```
+
+## Pull request workflow
+
+1. Fork the repository and create a topic branch from `main`.
+2. Make your change. Keep it focused — one logical change per PR.
+3. Run lint, type check, and tests locally before pushing:
+   ```bash
+   uv run ruff check . && uv run ruff format --check .
+   uv run ty check
+   # run the project's test command (often `just test` or `uv run pytest`)
+   ```
+4. Update docs if you changed behavior or public API.
+5. Open the PR using the template. Link the issue it resolves.
+
+## CI note
+
+GitHub occasionally type-checks a stale `refs/pull/<n>/merge` after a push, so a
+PR can show an old lint/test failure that no longer matches the branch. Confirm
+by running the failing check locally at the branch HEAD with the pinned tool
+version; if it's clean, push a fresh commit to force GitHub to recompute the
+merge ref.
+
+## Code of Conduct
+
+By participating you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Report vulnerabilities privately using GitHub's built-in private reporting:
+open the affected repository's **Security** tab and choose
+**"Report a vulnerability"**. This routes confidentially to the maintainers.
+
+Please include:
+
+- the affected project and version,
+- a description of the vulnerability and its impact,
+- steps to reproduce or a proof of concept, if available.
+
+We aim to acknowledge reports within a few days and will keep you informed as we
+investigate and prepare a fix. Once a fix is released, we're happy to credit you
+in the release notes unless you prefer to remain anonymous.
+
+## Supported versions
+
+Unless a repository states otherwise, security fixes target the **latest
+released version** on PyPI. Upgrading to the latest release is the recommended
+way to receive fixes.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,15 @@
+# Support
+
+Need help with a `modern-python` project? Here's where to go:
+
+- **Documentation:** start at [modern-python.org](https://modern-python.org) and
+  the project's own docs site (linked from each repo).
+- **Questions & usage help:** ask in
+  [GitHub Discussions](https://github.com/orgs/modern-python/discussions).
+- **Bugs & feature requests:** open an issue in the relevant repository using the
+  provided templates.
+- **Security issues:** see [SECURITY.md](SECURITY.md) — please report privately,
+  not in a public issue.
+
+Please search existing issues and discussions before opening a new one — your
+question may already be answered.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,13 +57,13 @@ wires them together.
 ## Project templates { #templates }
 
 - [`fastapi-sqlalchemy-template`](https://github.com/modern-python/fastapi-sqlalchemy-template) — dockerized web application with DI on FastAPI, SQLAlchemy 2, PostgreSQL.
-- [`litestar-sqlalchemy-template`](https://github.com/modern-python/litestar-sqlalchemy-template) — dockerized web application on LiteStar, SQLAlchemy 2, PostgreSQL.
+- [`litestar-sqlalchemy-template`](https://github.com/modern-python/litestar-sqlalchemy-template) — dockerized web application on Litestar, SQLAlchemy 2, PostgreSQL.
 
 ## Dependency injection { #di }
 
 - [`modern-di`](https://github.com/modern-python/modern-di) — powerful DI framework with scopes.
 - [`modern-di-fastapi`](https://github.com/modern-python/modern-di-fastapi) — `modern-di` integration for FastAPI.
-- [`modern-di-litestar`](https://github.com/modern-python/modern-di-litestar) — `modern-di` integration for LiteStar.
+- [`modern-di-litestar`](https://github.com/modern-python/modern-di-litestar) — `modern-di` integration for Litestar.
 - [`modern-di-faststream`](https://github.com/modern-python/modern-di-faststream) — `modern-di` integration for FastStream.
 - [`modern-di-typer`](https://github.com/modern-python/modern-di-typer) — `modern-di` integration for Typer.
 - [`modern-di-pytest`](https://github.com/modern-python/modern-di-pytest) — `modern-di` integration for pytest.


### PR DESCRIPTION
Adds default community-health files to the org `.github` repo so every repo that
lacks its own inherits them org-wide. Implements **Phase 0 (foundation hygiene)**
of the promotion strategy (`docs/superpowers/specs/2026-06-24-promotion-strategy-design.md`),
lifting community-health coverage from ~25% to ~90% across the org in one PR.

### Added (repo root)
- `CONTRIBUTING.md` — org-wide contributor guide (uv / ruff / ty workflow + CI gotcha)
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 (enforcement via GitHub private reporting, no email)
- `SECURITY.md` — private vulnerability reporting policy
- `SUPPORT.md` — where to get help (docs / Discussions / security)

### Added (`.github/`)
- `ISSUE_TEMPLATE/bug_report.yml`, `ISSUE_TEMPLATE/feature_request.yml` — issue forms
- `ISSUE_TEMPLATE/config.yml` — disables blank issues; routes questions to Discussions + docs
- `PULL_REQUEST_TEMPLATE.md` — default PR template

### Also
- Fixed `LiteStar` → `Litestar` casing on the docs landing page (`docs/index.md`).

### Skipped
- `FUNDING.yml` — intentionally omitted (no sponsor enrollment yet); can be added later.

### Manual follow-up (maintainer)
- [ ] Enable **org-level Discussions** (Org → Settings → Discussions) so the issue-chooser "Question" link resolves.
- [ ] Spot-check a repo with no templates of its own (e.g. `db-retry`) shows the inherited Bug/Feature chooser.

Verified: `uv run mkdocs build --strict` passes and none of the root community files leak into the published site.