### PR TITLE
docs: add 'The stack' narrative + fix site deploy (exclude planning docs)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,40 @@ wires them together.
 
 </div>
 
+## The stack { #stack }
+
+The modern-python projects fit together into one coherent stack for building
+production Python services. Use one piece or all of them — each is independent.
+
+- **Start from a template.**
+  [`fastapi-sqlalchemy-template`](https://github.com/modern-python/fastapi-sqlalchemy-template)
+  and [`litestar-sqlalchemy-template`](https://github.com/modern-python/litestar-sqlalchemy-template)
+  give you a dockerized, batteries-included app — FastAPI or Litestar,
+  SQLAlchemy 2, PostgreSQL, with dependency injection already wired.
+- **Wire your dependencies** with
+  [`modern-di`](https://github.com/modern-python/modern-di) — typed, scoped
+  dependency injection with one wiring shared across FastAPI, Litestar,
+  FastStream, and Typer.
+  ([`that-depends`](https://github.com/modern-python/that-depends), its
+  production-proven predecessor, is still maintained.)
+- **Call other services reliably** with
+  [`httpware`](https://github.com/modern-python/httpware) — an httpx-based client
+  with typed errors, typed response bodies, and a composable resilience chain
+  (retry, bulkhead, circuit breaker).
+- **Publish events reliably** with
+  [`faststream-outbox`](https://github.com/modern-python/faststream-outbox) — the
+  transactional outbox pattern for FastStream + PostgreSQL: write your domain row
+  and outbox row in one transaction, relay to any broker with one decorator.
+- **Instrument everything** with
+  [`lite-bootstrap`](https://github.com/modern-python/lite-bootstrap) —
+  OpenTelemetry, Prometheus, Sentry, and structlog wired into FastAPI, Litestar,
+  or FastStream in a few lines.
+
+Every project is built with the same tooling
+([`uv`](https://github.com/astral-sh/uv), [`ruff`](https://github.com/astral-sh/ruff),
+[`ty`](https://github.com/astral-sh/ty)) under the MIT license. Browse the full
+catalog below.
+
 ## Project templates { #templates }
 
 - [`fastapi-sqlalchemy-template`](https://github.com/modern-python/fastapi-sqlalchemy-template) — dockerized web application with DI on FastAPI, SQLAlchemy 2, PostgreSQL.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ repo_name: modern-python
 # Repo-internal docs that must not be published to the public site.
 exclude_docs: |
   DEPLOYMENT.md
+  superpowers/
 
 theme:
   name: material


### PR DESCRIPTION
### Adds — "The stack" narrative
An equal-billing section on the org landing page telling the how-it-fits-together story for building a production Python service:
**template → `modern-di` → `httpware` → `faststream-outbox` → `lite-bootstrap`**, each with a sharp pitch. Written as new prose so it does not drift from the canonical repo descriptions in the directory lists below it.

### Fixes — site deploy was broken
`.github/workflows/deploy.yml` runs `mkdocs build --strict`. The strategy spec + plans under `docs/superpowers/` contain repo-relative links (e.g. `CODE_OF_CONDUCT.md`) that mkdocs can't resolve, so **strict build — and the Pages deploy — has been failing since those docs were added** (PR #13). They were also being published to modern-python.org, which is undesirable for internal planning docs.

Fix: add `superpowers/` to `exclude_docs`. The files stay in the repo (version-controlled planning) but are no longer built or published.

Verified: `mkdocs build --strict` passes; `site/superpowers/` is gone; the stack section renders.