### PR TITLE
build: pin mkdocs<2 to stay clear of the MkDocs 2.0 rewrite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,13 @@ version = "0"
 description = "modern-python.org organization homepage"
 requires-python = ">=3.11"
 dependencies = [
-    "mkdocs-material>=9.5",
+    # MkDocs 2.0 is a backward-incompatible rewrite (no plugin system, no theme
+    # overrides) that breaks Material for MkDocs, with no migration path. Material
+    # 9.7.5+ already caps mkdocs<2; pin both explicitly so a fresh resolve can
+    # never pull MkDocs 2.0.
+    # https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/
+    "mkdocs>=1.6,<2",
+    "mkdocs-material>=9.7.5",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,7 @@ name = "modern-python-org"
 version = "0"
 source = { virtual = "." }
 dependencies = [
+    { name = "mkdocs" },
     { name = "mkdocs-material" },
 ]
 
@@ -410,7 +411,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mkdocs-material", specifier = ">=9.5" }]
+requires-dist = [
+    { name = "mkdocs", specifier = ">=1.6,<2" },
+    { name = "mkdocs-material", specifier = ">=9.7.5" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Why
The Material for MkDocs team is warning about **MkDocs 2.0**, a backward-incompatible ground-up rewrite of the core framework: it removes the plugin system, rewrites theming (breaking `custom_dir` overrides), switches config to TOML, and has **no migration path** — Material ceases to work entirely. It's also currently unlicensed. See their [analysis](https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/).

This site relies on exactly what 2.0 breaks (`overrides/main.html`, `extra_css`, markdown extensions).

## What
- Add an explicit `mkdocs>=1.6,<2` constraint.
- Bump `mkdocs-material` floor to `>=9.7.5` — the release that introduced the `mkdocs<2` cap — so a fresh resolve can never pull MkDocs 2.0.
- Relock (`uv.lock`): resolves to `mkdocs 1.6.1` / `mkdocs-material 9.7.6`, unchanged from today.

## Verification
- `uv lock` → `mkdocs 1.6.1`, `mkdocs-material 9.7.6`
- `uv run mkdocs build` → clean

A Zensical (the Material team's successor) migration was spiked and shelved on `spike/zensical` — it's viable but still alpha, so we stay on MkDocs 1.x for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)