### PR TITLE
Org profile: wordmark banner

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,9 @@
-## `Modern Python`
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/modern-python/.github/main/brand/org/wordmark-dark.svg">
+    <img alt="Modern Python" src="https://raw.githubusercontent.com/modern-python/.github/main/brand/org/wordmark.svg" width="360">
+  </picture>
+</p>
 
 Open-source templates and libraries for building production-ready Python applications — web services, microservices, and the dependency injection that wires them together.
 


### PR DESCRIPTION
Replaces the `## Modern Python` heading in `profile/README.md` (the org landing page) with a centered, theme-aware **wordmark** banner — green-ink `wordmark.svg` on light, cream `wordmark-dark.svg` on dark, via `<picture>`. Assets served from `brand/org/` on `main`. Description and the repo sections are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)