### PR TITLE
docs(planning): defer Zensical cutover with beta/1.0 revisit trigger

### DIFF
--- a/planning/deferred.md
+++ b/planning/deferred.md
@@ -1,3 +1,29 @@
 # Deferred
 
 Real-but-unscheduled items, each with a revisit trigger. Add entries lazily.
+
+## Zensical cutover for the docs sites
+
+**What:** Replace Material for MkDocs with [Zensical](https://zensical.org)
+(same team) as the builder for the org site and per-project docs sites.
+Validated feasible against Zensical 0.0.46 on 2026-07-05: a `zensical.toml`
+mirror of `mkdocs.yml` plus a one-block `overrides/main.html` tweak (dedupe the
+homepage `<title>` by title text) builds the current site cleanly under both
+builders. The spike branch was not kept — redo the port from `mkdocs.yml` when
+revisiting.
+
+**Why deferred:** Zensical is still pre-1.0 alpha (0.0.46 as of 2026-07-05, the
+latest release) with known gaps versus our current setup.
+
+**Revisit trigger — when Zensical reaches beta/1.0, re-check:**
+
+1. **`page.is_homepage`** (and siblings) exposed to custom templates. Today it
+   is undefined/falsy under Zensical; the spike works around it by deduping the
+   homepage `<title>` by title text.
+2. **`validation` parity** for the docs-heavy repos (e.g. `faststream-outbox`,
+   which runs `mkdocs build --strict`): `omitted_files` / orphaned-page
+   detection and `absolute_links` have **no** documented Zensical equivalent,
+   and several Zensical validation keys are still marked deprecated. `--strict`
+   itself and `invalid_links` / `invalid_link_anchors` do map.
+3. **`classic` variant fidelity** — that the traditional Material look still
+   matches the live site after the theme rewrite stabilizes.


### PR DESCRIPTION
## What

Records the Zensical evaluation as a `planning/deferred.md` item so the "wait for beta/1.0" decision and its concrete re-check list survive on `main`, independent of any spike branch.

## Why

We revisited the old `spike/zensical` reference. Findings:

- **Zensical is unchanged since the spike** — still `0.0.46` (2026-06-21, latest release); no beta/1.0.
- **Feasibility re-confirmed on 2026-07-05** against today's site: a `zensical.toml` mirror of `mkdocs.yml` + a one-block `overrides/main.html` tweak (dedupe the homepage `<title>` by title text, since Zensical alpha leaves `page.is_homepage` undefined) builds cleanly under both `uvx zensical@0.0.46 build` and `mkdocs build --strict`, with identical title/`og:title` output.
- **Known gaps keep it deferred**, captured as the revisit trigger:
  1. `page.is_homepage` (+ siblings) not exposed to custom templates.
  2. `validation` parity for strict docs repos (e.g. `faststream-outbox`): `omitted_files`/orphaned-page detection and `absolute_links` have no documented Zensical equivalent; several Zensical validation keys are still deprecated. `--strict`, `invalid_links`, `invalid_link_anchors` do map.
  3. `classic` variant fidelity after the theme rewrite stabilizes.

The feasibility spike branch was not kept; `mkdocs` remains the live builder.

## Verification

- `just check-planning` — OK