### PR TITLE
docs(profile): add Boosty support link and org-wide FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://boosty.to/lesnik512

--- a/profile/README.md
+++ b/profile/README.md
@@ -50,3 +50,9 @@ Open-source templates and libraries for building production-ready Python applica
 | [`db-retry`](https://github.com/modern-python/db-retry) | Retry helpers for PostgreSQL / SQLAlchemy database operations | [![Stars](https://img.shields.io/github/stars/modern-python/db-retry)](https://github.com/modern-python/db-retry/stargazers) | [![Downloads](https://static.pepy.tech/badge/db-retry/month)](https://pepy.tech/projects/db-retry) |
 | [`eof-fixer`](https://github.com/modern-python/eof-fixer) | Automatically fix newlines at the end of files | [![Stars](https://img.shields.io/github/stars/modern-python/eof-fixer)](https://github.com/modern-python/eof-fixer/stargazers) | [![Downloads](https://static.pepy.tech/badge/eof-fixer/month)](https://pepy.tech/projects/eof-fixer) |
 | [`semvertag`](https://github.com/modern-python/semvertag) | Auto-tag your GitHub/GitLab repo with semantic version tags from CI | [![Stars](https://img.shields.io/github/stars/modern-python/semvertag)](https://github.com/modern-python/semvertag/stargazers) | [![Downloads](https://static.pepy.tech/badge/semvertag/month)](https://pepy.tech/projects/semvertag) |
+
+### Support
+
+If these projects save you time, consider supporting development on [Boosty](https://boosty.to/lesnik512).
+
+[![Boosty](https://img.shields.io/badge/Boosty-support-f15f2c?logo=boosty&logoColor=white)](https://boosty.to/lesnik512)


### PR DESCRIPTION
## Summary
- Add a Support section with a Boosty badge to `profile/README.md` (org GitHub profile page)
- Add repo-root `FUNDING.yml` (`custom: https://boosty.to/lesnik512`) — enables the org-wide Sponsor button on repos without their own FUNDING.yml, via this repo's default community-health-file role

## Test plan
- [x] Verified `boosty` icon exists in simple-icons and the shields.io badge renders the correct logo
- [ ] Confirm Sponsor button appears on repos across the org after merge