### PR TITLE
docs(profile): drop the type badge column from the templates table

### DIFF
--- a/architecture/org-profile.md
+++ b/architecture/org-profile.md
@@ -20,17 +20,16 @@ frontmatter; dated by git.
    pyproject `description`, and this blurb). The three published-library
    tables (DI, microservices, utilities) share the shape
    `Project | What it is | Stars | Downloads`; the templates table is
-   `Project | What it is | Stars | Badges`.
+   `Project | What it is | Stars`.
 
 ## Badge rules
 
 - **Published libraries** get a Stars shield → stargazers, and a monthly
   Downloads shield (`static.pepy.tech/badge/<pkg>/month`) → the pepy project
   page.
-- **Templates** (`*-sqlalchemy-template`, not on PyPI) get a Stars shield and,
-  in their Badges cell, only a static `type: template` chip — templates have
-  no Downloads column, hence that column keeps the generic "Badges" header
-  instead of "Downloads".
+- **Templates** (`*-sqlalchemy-template`, not on PyPI) get a Stars shield only —
+  they have no Downloads column, and their table stops after Stars rather than
+  carrying a filler chip.
 - All badges use flat (default) style so row heights align. Downloads use the
   pepy baked SVG, not the flaky shields `pypi/dm` endpoint. Every number is a
   live shield (no hand-typed stats that could go stale).

--- a/planning/changes/2026-07-13.03-drop-template-type-badge.md
+++ b/planning/changes/2026-07-13.03-drop-template-type-badge.md
@@ -1,0 +1,36 @@
+---
+summary: Drop the static `type: template` chip and its Badges column from the profile templates table, leaving `Project | What it is | Stars`.
+---
+
+# Change: Drop the type badge from the profile templates table
+
+**Lane:** lightweight — docs-only, 2 files, no public-API change.
+
+## Goal
+
+The **Project templates** table in `profile/README.md` carried a fourth column
+holding a static `type: template` chip. It conveys nothing the section heading
+does not already say, and it exists only to fill the slot where the other three
+tables put Downloads. Remove the chip and the column.
+
+## Approach
+
+The templates table becomes `Project | What it is | Stars`. The published-library
+tables (DI, microservices, utilities) are untouched and keep their Downloads
+column — table shapes differing by category is fine, since each is read on its
+own. Promote the new shape into `architecture/org-profile.md`, which documented
+both the header name and the chip.
+
+## Files
+
+- `profile/README.md` — templates table: drop the `Badges` header, its separator
+  cell, and the chip from both template rows.
+- `architecture/org-profile.md` — update the templates table shape and the badge
+  rule that described the chip.
+
+## Verification
+
+- [ ] `just check-planning` — planning index clean.
+- [ ] `just test` — full suite green.
+- [ ] Templates table renders with three columns; no `type-template` shield URL
+      remains anywhere in the repo.

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,10 +14,10 @@ Open-source templates and libraries for building production-ready Python applica
 
 ### Project templates
 
-| Project | What it is | Stars | Badges |
-|---|---|---|---|
-| [`fastapi-sqlalchemy-template`](https://github.com/modern-python/fastapi-sqlalchemy-template) | Dockerized FastAPI + SQLAlchemy 2 + PostgreSQL app template with DI | [![Stars](https://img.shields.io/github/stars/modern-python/fastapi-sqlalchemy-template)](https://github.com/modern-python/fastapi-sqlalchemy-template/stargazers) | ![Template](https://img.shields.io/badge/type-template-blue) |
-| [`litestar-sqlalchemy-template`](https://github.com/modern-python/litestar-sqlalchemy-template) | Dockerized Litestar + SQLAlchemy 2 + PostgreSQL app template with DI | [![Stars](https://img.shields.io/github/stars/modern-python/litestar-sqlalchemy-template)](https://github.com/modern-python/litestar-sqlalchemy-template/stargazers) | ![Template](https://img.shields.io/badge/type-template-blue) |
+| Project | What it is | Stars |
+|---|---|---|
+| [`fastapi-sqlalchemy-template`](https://github.com/modern-python/fastapi-sqlalchemy-template) | Dockerized FastAPI + SQLAlchemy 2 + PostgreSQL app template with DI | [![Stars](https://img.shields.io/github/stars/modern-python/fastapi-sqlalchemy-template)](https://github.com/modern-python/fastapi-sqlalchemy-template/stargazers) |
+| [`litestar-sqlalchemy-template`](https://github.com/modern-python/litestar-sqlalchemy-template) | Dockerized Litestar + SQLAlchemy 2 + PostgreSQL app template with DI | [![Stars](https://img.shields.io/github/stars/modern-python/litestar-sqlalchemy-template)](https://github.com/modern-python/litestar-sqlalchemy-template/stargazers) |
 
 ### Dependency injection
 


### PR DESCRIPTION
The **Project templates** table in `profile/README.md` carried a fourth column holding a static `type: template` chip. It conveyed nothing the section heading did not already say, and existed only to fill the slot where the other three tables put Downloads. The table is now `Project | What it is | Stars`; the published-library tables are untouched and keep Downloads.

`architecture/org-profile.md` is updated in the same PR — both the templates table shape and the badge rule that described the chip.

Change file: `planning/changes/2026-07-13.03-drop-template-type-badge.md` (Lightweight lane).

Verified: `just check-planning` OK, `just test` 149 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)