### PR TITLE
docs(community): enable Discussions on the three launch repos

### DIFF
--- a/architecture/community.md
+++ b/architecture/community.md
@@ -6,10 +6,23 @@ dated by git.
 ## What exists today
 
 **GitHub Discussions is the org's only owned channel**, and its primary support
-and feedback surface. It is enabled on `modern-di`, `that-depends`, and `.github`
-— not yet org-wide. There is deliberately **no Discord and no Telegram room**:
-see `planning/deferred.md`, which holds the plan to open them and the reason they
-are not open yet.
+and feedback surface. It exists at two levels:
+
+- **Org-level** — [`/orgs/modern-python/discussions`](https://github.com/orgs/modern-python/discussions),
+  backed by this `.github` repo. This is the catch-all forum, and the one
+  [`SUPPORT.md`](../SUPPORT.md) routes every project's users to.
+- **Per-repo** — enabled on `modern-di`, `that-depends`, and the three repos the
+  launch promotes: `httpware`, `faststream-outbox`, `lite-bootstrap`. Deliberately
+  **not** enabled org-wide: 20-odd empty Discussion tabs would read as a dead
+  project, the same empty-room failure described below. A repo gets its own tab
+  when it has traffic to fill it.
+
+Only `that-depends` has real activity today; the other surfaces are seeded but
+empty, and launch traffic is what is expected to fill them.
+
+There is deliberately **no Discord and no Telegram room**: see
+`planning/deferred.md`, which holds the plan to open them and the reason they are
+not open yet.
 
 ## Why Discussions, and why nothing else yet
 


### PR DESCRIPTION
Follow-up to #45, which documented Discussions as the org's primary support surface and immediately exposed that it was barely enabled.

## The gap

`httpware`, `faststream-outbox` and `lite-bootstrap` are the three repos the launch playbook actually promotes, and **none of them had a Discussions tab**. Launch traffic would have landed with nowhere native to ask a question.

Enabled on those three (via the API; no repo files changed). The org now has Discussions on `modern-di`, `that-depends`, `.github`, `httpware`, `faststream-outbox`, `lite-bootstrap`.

## Why not org-wide

`promotion-strategy` Phase 5 says "enable Discussions org-wide", but that contradicts the channel doctrine's own empty-room argument: 20-odd empty Discussion tabs read as a dead project, exactly the failure the doctrine rejects for chat rooms. A repo gets a tab when it has traffic to fill it. That reasoning is now written down rather than left as a tension between two planning docs.

## What I found while doing it

- **`SUPPORT.md` already routes to an org-level forum** (`/orgs/modern-python/discussions`, backed by this repo) that the earlier analysis hadn't accounted for. `architecture/community.md` now describes both levels and which one SUPPORT routes to.
- **Only `that-depends` has real activity** (12 threads). Every other surface, including the org-level one, is empty. Recorded plainly rather than implying a healthy forum.

`just check-planning`: OK.