### PR TITLE
fix(docs): enable admonition extension; fix DI steer line breaks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,7 @@ catalog below.
     the resolve path itself stays synchronous, and resources that need to `await` are
     constructed in the framework lifespan
     ([recipe](https://modern-di.modern-python.org/recipes/async-lifespan/)).
+
     [`that-depends`](https://github.com/modern-python/that-depends) is the async-first
     sibling and stays maintained; it ships a migration guide to `modern-di`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ extra_css:
   - stylesheets/extra.css
 
 markdown_extensions:
+  - admonition
   - attr_list
   - md_in_html
   - pymdownx.emoji:

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,12 +21,9 @@ Open-source templates and libraries for building production-ready Python applica
 
 ### Dependency injection
 
-**Which one?** Start new projects on [`modern-di`](https://github.com/modern-python/modern-di)
-— a minimal core plus the integrations below. Async apps are first-class: the
-resolve path itself stays synchronous, and resources that need to `await` are built
-in the framework lifespan. [`that-depends`](https://github.com/modern-python/that-depends)
-is the async-first sibling and stays maintained; it ships a migration guide to
-`modern-di`.
+**Which one?** Start new projects on [`modern-di`](https://github.com/modern-python/modern-di) — a minimal core plus the integrations below. Async apps are first-class: the resolve path itself stays synchronous, and resources that need to `await` are built in the framework lifespan.
+
+[`that-depends`](https://github.com/modern-python/that-depends) is the async-first sibling and stays maintained; it ships a migration guide to `modern-di`.
 
 | Project | What it is | Stars | Downloads |
 |---|---|---|---|


### PR DESCRIPTION
Two rendering bugs in the DI steer that shipped in #48. **One is currently live.**

## 1. modern-python.org is serving raw markup

The `admonition` extension was **never enabled** in `mkdocs.yml` (only `attr_list`, `md_in_html`, `pymdownx.emoji`). So the `!!! tip` block fell through as literal text — the site right now renders:

> `!!! tip "Which one should I use?"`

…followed by the body as a raw `<pre><code>` block. Confirmed against the live site.

`mkdocs build --strict` passed the whole time, because a fell-through admonition is still *valid markdown* — just not the markdown you meant. The site had no other admonition anywhere, so nothing had ever exercised the extension.

## 2. GitHub turned my line wraps into `<br>`

GFM renders a single newline as `<br>`, so the hard-wrapped steer broke mid-sentence in **8 places** ("...first-class: the" / "...`await` are built"). The rest of `profile/README.md` sidesteps this by leaving prose unwrapped — the tagline is a single 173-char line.

## Fix

Enable `admonition`, and write the steer as **two blank-line-separated paragraphs** on both surfaces. That renders identically under GFM and Python-Markdown, as two real `<p>` blocks, with no `<br>` tricks and no reliance on how each parser treats newlines.

## Verification

Rendered both surfaces and inspected the HTML, rather than trusting the build:

| Surface | Result |
|---|---|
| `profile/README.md` via GitHub's markdown API | 4 `<table>`, **0** `<br>`, 2 `<p>` in the steer |
| `site/index.html` | real `<div class="admonition tip">` with title + 2 paragraphs; no literal `!!!` |

`just check-planning`: OK. `mkdocs build --strict`: clean.