### PR TITLE
docs(agents): configure the engineering skills for this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,11 @@ one file per capability plus `glossary.md`, no frontmatter, authored lazily.
 **When a change alters a capability's behavior, update the matching
 `architecture/<capability>.md` in the same PR.** The change file in
 `planning/changes/` stays as the *why*.
+
+## Agent skills
+
+- **Issues and specs** — GitHub Issues on `modern-python/.github`, via `gh`:
+  [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md)
+- **Triage labels** — the five canonical roles: [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md)
+- **Domain docs** — single-context, `architecture/` + `planning/`:
+  [`docs/agents/domain.md`](docs/agents/domain.md)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,69 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring
+the codebase.
+
+This repo does **not** use the stock `CONTEXT.md` + `docs/adr/` layout. It follows the
+two-axis planning convention (applied version in `planning/.convention-version`), which
+already has a home for each role. Use the repo's own files — do not create `CONTEXT.md`,
+`CONTEXT-MAP.md`, or `docs/adr/`.
+
+## Layout: single-context
+
+| Stock skill concept                | This repo                                      |
+| ---------------------------------- | ---------------------------------------------- |
+| `CONTEXT.md` (ubiquitous language) | `architecture/glossary.md`                     |
+| what the system does now           | `architecture/<capability>.md`, one per capability |
+| `docs/adr/` (durable decisions)    | `planning/decisions/<YYYY-MM-DD>-<slug>.md`    |
+| the *why* behind a shipped change  | `planning/changes/<YYYY-MM-DD>.NN-<slug>.md`   |
+
+## Before exploring, read these
+
+- `architecture/README.md`, then the `architecture/<capability>.md` files touching your
+  area. This is the living truth about what the repo does now.
+- `architecture/glossary.md` — the ubiquitous language.
+- `planning/decisions/*.md` whose subject touches your area. Each carries
+  `status: accepted | superseded`; a superseded decision is history, follow
+  `superseded_by`.
+- `planning/changes/*.md` for the rationale behind a specific past change.
+  `just index` prints the change/decision listing.
+
+If any of these don't exist, **proceed silently**. Don't flag their absence; don't suggest
+creating them upfront. `architecture/glossary.md` in particular is authored lazily — it
+appears when the first term is worth pinning down.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (an issue title, a refactor proposal, a
+hypothesis, a test name), use the term as defined in `architecture/glossary.md`, and
+honor its `_Avoid_:` lines — those synonyms are rejected on purpose.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're
+inventing language the project doesn't use (reconsider) or there's a real gap (note it
+for `/domain-modeling`).
+
+## Writing back
+
+Domain docs here are written under the planning convention, not freehand:
+
+- **A new or sharpened term** → edit `architecture/glossary.md` in the same PR as the
+  change. No frontmatter; each entry is a term, a one-or-two-sentence definition of what
+  it *is*, and an optional `_Avoid_:` line. Seed a new file from
+  `planning/_templates/glossary.md`.
+- **A behavior change** → hand-edit the affected `architecture/<capability>.md` in the
+  implementing PR, alongside the code. Never as a separate post-merge step.
+- **A design decision, especially a rejected option** → a new
+  `planning/decisions/<YYYY-MM-DD>-<slug>.md` from `planning/_templates/decision.md`,
+  including its **Revisit trigger**.
+- Run `just check-planning` before pushing.
+
+## Flag conflicts
+
+If your output contradicts an accepted decision or a capability page, surface it
+explicitly rather than silently overriding:
+
+> _Contradicts `planning/decisions/2026-06-29-project-marks-single-gold-inner.md`, but
+> worth reopening because…_
+
+A decision's **Revisit trigger** names the concrete signal that should reopen it. If that
+signal has fired, say so.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ repo_name: modern-python
 # Repo-internal docs that must not be published to the public site.
 exclude_docs: |
   DEPLOYMENT.md
+  /agents/
 
 theme:
   name: material

--- a/planning/changes/2026-09-06.01-agent-skills-config.md
+++ b/planning/changes/2026-09-06.01-agent-skills-config.md
@@ -1,0 +1,76 @@
+---
+summary: Add docs/agents/ so the engineering skills read this repo's tracker, triage labels and domain homes; keep it out of the published site.
+---
+
+# Design: Configure the engineering skills for this repo
+
+## Summary
+
+The engineering skills (`/triage`, `/code-review`, `/to-tickets`, `/to-spec`,
+`/domain-modeling`) expect a `docs/agents/` config naming the issue tracker, the triage
+label vocabulary, and where domain documentation lives. This repo had none, so `/triage`
+could not run here. This adds the three files, links them from `CLAUDE.md`, and keeps them
+out of the published site.
+
+## Motivation
+
+`/triage` on `modern-python/.github` halted immediately: no `docs/agents/issue-tracker.md`,
+no label mapping, and only `wontfix` of the five state labels existed on the repo.
+`code-review` hardcodes the same path when resolving issue references from commit
+messages. `modern-di` and `faststream-outbox` have carried this config for some time;
+`.github` was the outlier.
+
+## Design
+
+Three files under `docs/agents/`, seeded from the setup skill's templates:
+
+- `issue-tracker.md` — GitHub Issues via `gh`. PRs as a request surface: **no**.
+- `triage-labels.md` — the five canonical roles, each label string equal to its role name.
+  The four missing labels (`needs-triage`, `needs-info`, `ready-for-agent`,
+  `ready-for-human`) were created on the repo with the colors and descriptions already
+  used by `modern-di`.
+- `domain.md` — **adapted, not stock.** The template points skills at `CONTEXT.md` +
+  `docs/adr/`. Neither exists here, and creating them would duplicate what `planning/`
+  already owns. It instead maps each role onto this repo's convention:
+
+  | Stock concept                      | Here                          |
+  | ---------------------------------- | ----------------------------- |
+  | `CONTEXT.md` (ubiquitous language) | `architecture/glossary.md`    |
+  | what the system does now           | `architecture/<capability>.md`|
+  | `docs/adr/` (durable decisions)    | `planning/decisions/`         |
+  | the *why* behind a change          | `planning/changes/`           |
+
+  It also carries a "Writing back" section, so a skill recording a decision seeds it from
+  `planning/_templates/decision.md` with a Revisit trigger and runs `just check-planning`.
+
+`CLAUDE.md` gains an `## Agent skills` section in the bullet format already used by the
+other two repos, not the sub-heading form the setup template suggests.
+
+`docs/` is the MkDocs source for modern-python.org, so `/agents/` joins `DEPLOYMENT.md` in
+`exclude_docs` — matching how `modern-di` and `faststream-outbox` exclude theirs.
+
+## Non-goals
+
+- Resolving #50. `domain.md` describes the repo as it is today; if PR-body-as-spec is
+  adopted, it is rewritten there.
+- Aligning the three repos' domain conventions. That divergence is real, and is #50's
+  subject.
+- Authoring `architecture/glossary.md`. It stays lazily authored.
+
+## Testing
+
+- `just check-planning` → `planning: OK`.
+- `uv run mkdocs build --strict` succeeds and the built site contains no `agents/`
+  directory — the config does not reach modern-python.org.
+- `gh label list` shows all seven triage labels on the repo.
+
+## Risk
+
+Low; no runtime or packaging surface is touched. The main exposure is `domain.md` going
+stale against #50 — mitigated by it being one file with a single owner, rewritten as part
+of that change.
+
+One latent defect is inherited from the stock template: `issue-tracker.md` documents
+filtering external PRs by `authorAssociation` on `gh pr list`, a field `gh` 2.98.0
+rejects. It is unreachable while PRs-as-request-surface is `no`, and the same line sits in
+both sibling repos — worth a separate sweep.


### PR DESCRIPTION
## Summary

`/triage` could not run on this repo: there was no `docs/agents/` config naming the issue
tracker, the triage label vocabulary or the domain-doc homes, and four of the five triage
state labels did not exist. `modern-di` and `faststream-outbox` have carried this config
for some time — `.github` was the outlier.

Rationale and the rejected-alternative reasoning live in the change file:
[`planning/changes/2026-09-06.01-agent-skills-config.md`](planning/changes/2026-09-06.01-agent-skills-config.md).

## Changes

- Add `docs/agents/issue-tracker.md` (GitHub via `gh`; PRs as a request surface: **no**).
- Add `docs/agents/triage-labels.md` — the five canonical roles, each mapping to itself.
- Add `docs/agents/domain.md`, **adapted rather than stock**: it maps the skills'
  `CONTEXT.md` + `docs/adr/` model onto this repo's `architecture/` + `planning/`
  convention instead of introducing a second truth home.
- Link all three from a new `## Agent skills` section in `CLAUDE.md`, in the bullet format
  the sibling repos already use.
- Exclude `/agents/` from the published site in `mkdocs.yml` — `docs/` is the
  modern-python.org source.

Out of band, on the repo itself: created `needs-triage`, `needs-info`, `ready-for-agent`
and `ready-for-human`, mirroring the colors and descriptions `modern-di` uses.

## Notes for review

- `domain.md` describes the repo as it is **today**. #50 proposes moving `.github` to
  PR-body-as-spec, which would invalidate it; that rewrite belongs to #50, not here.
- `issue-tracker.md` inherits a latent template defect: it documents filtering external
  PRs by `authorAssociation` on `gh pr list`, a field `gh` 2.98.0 rejects. Unreachable
  while the PRs flag is `no`, and the same line sits in both sibling repos — worth a
  separate sweep.

## Checklist

- [x] Lint and format pass (`ruff`) — no Python touched
- [x] Type check passes (`ty`) — no Python touched
- [x] Tests pass and new behavior is covered — `just check-planning` → `planning: OK`
- [ ] Build succeeds (`uv build`) if packaging or build config changed — n/a
- [x] Docs updated if behavior or public API changed — `uv run mkdocs build --strict`
      succeeds; built site contains no `agents/` directory
- [ ] Repo metadata stays consistent across the three surfaces — n/a
