### PR TITLE
ci: check external links weekly, opening an issue when one dies

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,42 @@
+name: Links
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Checks github.com through the API instead of scraping it, which is what
+          # keeps 55 repo links off the anonymous rate limit.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # /stargazers is login-walled — it 404s for anonymous clients on every
+          # repo, ours and psf/requests alike. pepy download badges 404 by design
+          # until a listed package reaches PyPI (AGENTS.md), and test_profile.py
+          # already pins each badge to its repo name.
+          args: >-
+            --cache
+            --max-cache-age 1d
+            --no-progress
+            --exclude 'github\.com/.*/stargazers'
+            --exclude 'static\.pepy\.tech'
+            '**/*.md'
+          fail: false
+      - name: Open an issue on failure
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Broken links found
+          content-filepath: ./lychee/out.md
+          labels: documentation


### PR DESCRIPTION
## Why

`profile/README.md` is the org landing page — the first thing anyone sees at
github.com/modern-python — and it is built almost entirely out of external URLs:

| Host | count |
|---|---|
| github.com | 55 |
| img.shields.io | 31 |
| pepy.tech + static.pepy.tech | 48 |
| raw.githubusercontent.com | 2 |
| docs sites, boosty | 3 |

**139 unique URLs, and nothing has ever checked one of them.** `mkdocs build --strict`
validates links inside `docs/`; `profile/` is not part of the site at all.

The failure this closes is concrete. Per [ADR 0003](../blob/main/docs/adr/0003-docs-vendor-assets-readmes-hotlink.md)
every repo README in the org hotlinks its lockup from `brand/projects/<repo>/` here by
absolute URL — so moving or renaming an asset breaks banners across 26 repos at once,
with no build anywhere that notices. A renamed repo does the same to its own row.

## Design

Weekly, `fail: false`, opening an issue — lychee's own documented pattern. **Not a PR
gate:** whether shields.io is up is not a property of a diff, and gating merges on
third-party availability trains people to ignore red.

Two exclusions, both measured rather than assumed:

- **`/stargazers`** — 404s for anonymous clients on **every** repo, ours and
  `psf/requests` alike. It is login-walled, not broken. 26 URLs, 19% of the total,
  which would all be reported dead on the first run.
- **pepy download badges** — 404 by design until a listed package reaches PyPI, which
  `AGENTS.md` documents as self-healing and never a blocker. All 24 are published
  today, so this is pre-emptive; `test_profile.py` already pins each badge to its repo
  name, so the check would add nothing.

`token: ${{ secrets.GITHUB_TOKEN }}` makes github.com links resolve through the API
rather than being scraped, which is what keeps 55 links off the anonymous rate limit.

## Non-goals

- Not run on PRs, and not on `push`.
- Scoped to `'**/*.md'`. That does put the ADR links in `AGENTS.md` under a check for
  the first time, but the citations in `brand/README.md` and `symbols.py` are inline
  code rather than links and stay unchecked — deliberately, per the research on #61.

## Verification

The 89 URLs remaining after both exclusions were probed before committing: **89 of 89
healthy**, so the first run should open nothing. One `img.shields.io` request timed out
during the probe and passed on retry; lychee's `--max-retries` defaults to 3, so that
case is already handled.

Every flag was checked against lychee's own docs rather than recalled: `--cache`,
`--max-cache-age`, `--no-progress`, `--exclude` (regex), glob inputs, and the action's
`lychee/out.md` output path and `exit_code` output. `.lock` is not among lychee's
default extensions, so `uv.lock`'s package URLs stay out of scope.

Scheduled workflows only run from the default branch, so this cannot be exercised until
it is on `main`. It carries `workflow_dispatch` so it can be triggered immediately after
merge — I'd like to do that and report the real first run rather than leave it to fire
unattended on Monday.