### PR TITLE
ci: gate PRs on local links, and stop publishing the ADRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ jobs:
       - name: Build site
         run: uv run mkdocs build --strict
 
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # --offline blocks network requests and excludes every external URL, so this
+      # gate is deterministic: it fails only on a relative link or file path that a
+      # diff actually broke. External rot is the weekly links.yml run's job.
+      - name: Check local links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline
+            --no-progress
+            '**/*.md'
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,9 +8,6 @@ repo_name: modern-python
 exclude_docs: |
   DEPLOYMENT.md
   /agents/
-
-# ADRs are built (so their outgoing links are validated) but stay out of the site menu.
-not_in_nav: |
   /adr/
 
 theme:


### PR DESCRIPTION
## Why

#63 put all link checking on a weekly schedule, justified by flakiness. That reason
holds for external URLs and does not hold for the rest.

A relative link breaks because **a diff broke it**. The survey behind #64 found ~66 dead
relative links across the org — 55 in one repo, from a `planning/` directory reorg. That
was a PR, and nothing caught it. Those checks need no network, cannot flake, and belong
on the PR that breaks them.

External URLs rot on someone else's clock with no diff involved: `faststream.airt.ai`
404s today because the project moved. A PR gate can never catch that; the weekly run can.

## Design

Split by determinism:

| | Catches | Where |
|---|---|---|
| `lychee --offline` | relative links and file paths — deterministic, diff-caused | **PR gate**, blocking |
| full `lychee` | external URL rot — non-deterministic, not diff-caused | weekly, unchanged |

**The ADRs stop being published.** `not_in_nav` existed for one reason: build them so
`mkdocs --strict` validates their outgoing links, at the price of publishing internal
decision records on the org's marketing site at `modern-python.org/adr/…`. The PR gate
validates those links now, from disk, so they move to `exclude_docs`. Nothing under
`docs/` links into `docs/adr/`, so the build stays clean.

## Non-goals

- No change to `links.yml`; the weekly external run and its exclusions are untouched.
- The duplicate-issue defect in `links.yml` (`create-issue-from-file` does not dedupe)
  is real and separate — it wants the org's own label-keyed find-or-comment idiom.
- **Whether the library repos should also unpublish their ADRs is their call.**
  `modern-di` chose `not_in_nav` deliberately across 27 ADRs, and public design records
  arguably suit a library docs site in a way they do not suit an org landing page.

## Verification

Run locally against the lychee container rather than assumed:

- `--offline` **excludes** external URLs rather than erroring on them — 229 total, 32
  local links checked, 197 excluded, **0 errors**. That is what makes the gate safe to
  block on.
- **Red-checked:** renaming `docs/adr/0003-…` makes it fail with
  `[ERROR] file:///input/docs/adr/0003-renamed-oops.md (at 56:1) | File not found`,
  naming the citing file and line. That is the check the invariant census performed
  before #61 removed it — now a standard tool, on every PR, covering the root Markdown
  `mkdocs --strict` cannot see.
- `mkdocs build --strict` clean; `site/adr/` confirmed gone.