### PR TITLE
ci: stop the weekly link check opening a duplicate issue every run

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -33,10 +33,32 @@ jobs:
             --exclude 'static\.pepy\.tech'
             '**/*.md'
           fail: false
-      - name: Open an issue on failure
+      # create-issue-from-file does not deduplicate — it calls issues.create
+      # unconditionally, so six weeks of one dead link is six identical issues. This is
+      # the same find-or-comment shape every repo's report-scheduled-failure.sh uses.
+      - name: Open or update the tracking issue
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: Broken links found
-          content-filepath: ./lychee/out.md
-          labels: documentation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          LABEL="broken-links"
+          gh label create "$LABEL" \
+            --color "D93F0B" \
+            --description "Weekly external link check failures" \
+            --force
+          # The report is what changes week to week, so each comment carries the current
+          # one; 30k keeps a long report inside GitHub's comment limit.
+          report=$(head -c 30000 lychee/out.md 2>/dev/null || echo "(no report file produced)")
+          existing=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$existing" ]; then
+            gh issue create --title "Broken links found" --label "$LABEL" --body "$(printf '%s\n\n%s\n\n%s' \
+              "The weekly external link check failed. Close this issue once the links are fixed; the next failure opens a fresh one." \
+              "First failing run: ${RUN_URL}" \
+              "$report")"
+          else
+            gh issue comment "$existing" --body "$(printf '%s\n\n%s' \
+              "Still failing: ${RUN_URL}" \
+              "$report")"
+          fi


### PR DESCRIPTION
## Why

`peter-evans/create-issue-from-file` **does not deduplicate.** Confirmed from its source at
`v5`, not inferred: with no `issue-number` input it calls `issues.create` unconditionally —
there is no title search, no label search, and no state check anywhere in it.

So one link that stays broken for six weeks produces **six identical issues** titled
"Broken links found". An upstream issue about exactly this is still open, with the
maintainer declining to add dedup to that action ("much better to separate this
functionality into a new action") and a user reporting it "kept creating an infinite amount
of issues at each workflow run".

Two things worth noting about how this got here:

- **lychee-action's own README, and its own `links.yml`, recommend that naive pairing.** #63
  copied upstream's advice, and upstream's advice is wrong for anything that stays broken.
- It made this the **only issue-opening workflow in the org that did not deduplicate**.

## Design

Adopt the shape the org already settled on. Every repo's `report-scheduled-failure.sh` does
label-keyed find-or-comment with `gh`: ensure the label, look for an open issue carrying it,
create if absent, comment if present.

Comments **accumulate**, which is the reason to prefer this over the third-party options —
`create-issue-from-file`'s `issue-number` path and `JasonEtco/create-an-issue`'s
`update_existing` both overwrite title and body, so you lose which weeks failed and why.
Each comment carries the current report, since that is the part that changes week to week.

A dedicated `broken-links` label keeps this a distinct failure class from
`scheduled-failure`.

## Non-goals

- **No auto-close on a green run.** The org idiom does not, and a self-closing issue can
  flap weekly against an intermittently reachable host. You close it when it is fixed.
- No change to what lychee checks, or to the schedule.

## Verification

The `run:` block was extracted and all three branches exercised against a stubbed `gh`:

| Case | Result |
|---|---|
| no open issue | creates one |
| open issue #42 | comments on it |
| report file missing | still creates, does not abort |

Exit 0 in every case. The first run of this can't be exercised for real without a genuinely
broken external link, which the repo does not currently have — the last run was 229 links,
0 errors.