### PR TITLE
docs: keep the generic PR template as a deliberate org default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,4 @@
 - [ ] Type check passes (`ty`)
 - [ ] Tests pass and new behavior is covered
 - [ ] Build succeeds (`uv build`) if packaging or build config changed
-- [ ] Docs updated if behavior or public API changed
 - [ ] Repo metadata stays consistent across the three surfaces (GitHub description, pyproject `description`, profile blurb) if this touches packaging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,7 @@
-# modern-python org conventions
+# modern-python/.github
 
-The conventions below apply across **all** repos in the `modern-python` org, not
-just this one. [`CONTEXT.md`](CONTEXT.md) says what this repo is and owns the
-vocabulary — read it before naming a mark, a colourway, or a surface.
+[`CONTEXT.md`](CONTEXT.md) says what this repo is and owns the vocabulary — read it
+before naming a mark, a colourway, or a surface.
 
 ## Naming & branding
 
@@ -78,11 +77,6 @@ if it's clean, push a fresh commit to force GitHub to recompute the merge ref.
 non-goals, verification, reviewed with the diff. There is no change file, no lane to
 choose, and no `planning/` tree. A trivial PR (typo, dep bump, formatter, CI tweak)
 ships a conventional-commit title with no body ceremony.
-
-> This repo's `.github/PULL_REQUEST_TEMPLATE.md` is the **org default**, inherited by
-> every repo without a local one, and most of them still run the older `planning/`
-> convention — so it still carries the generic form. Replacing it is tracked
-> separately; write PR bodies in the shape above regardless.
 
 Two things outlive the PR, and there are exactly two places to put them: an
 alternative **rejected** with reasoning becomes an ADR in [`docs/adr/`](docs/adr/)


### PR DESCRIPTION
## Why

The org default PR template is inherited by every repo without a local one, and its
checklist carries `Docs updated if behavior or public API changed`. That is the
pre-convention question, the one this org stopped asking: it prompts for a page
update rather than the admission check, and it is untrue for any repo where behaviour
detail lives in `INVARIANT:` tests rather than prose.

Separately, this file opens by claiming its conventions apply across all repos in the
org. They do not. `AGENTS.md` is not a GitHub default community health file, so it is
never inherited, and no other repo's `AGENTS.md` references this one. An agent reads
exactly the file in the checkout it is standing in.

## Design

Keep the template as the org default and delete the one untrue line. What remains
(lint, type check, tests, build, metadata) holds under either convention, so the
inherited form is correct everywhere for the first time.

`AGENTS.md` loses three lines and gains none. The opening claim goes, and nothing
replaces it: an agent reading this file is already standing in this repo and cannot
act on a statement about repos it will never see. The heading follows, becoming
`# modern-python/.github` to match `CONTEXT.md`, since "org conventions" asserts the
same reach the paragraph just gave up.

The Workflow blockquote goes for the same reason. It existed to explain why the
template contradicts the convention, to an agent that opens a PR with
`gh pr create --body` and never reads the template. Its one actionable clause, "write
PR bodies in the shape above", is the paragraph directly above it.

## Non-goals

- **The local templates in `modern-di`, `faststream-outbox` and `chat-app`.** Deleted
  in their own PRs; this one only makes the default they fall back to correct.
- **`that-depends`.** Keeps its local template, which is the only one in the org
  measurably in use.
- **The ADR revisit-trigger phrase**, still on line 91. #53 decided not to propagate
  it to the other repos; removing it here would change this repo's own practice and is
  a separate call.
- **`CONTEXT.md:8`**, which repeats the org-wide claim just deleted here. It needs the
  same fix and is mid-edit on another branch.

## Verification

`uv run pytest`: 123 passed, 26 skipped, 5 failed. All five failures are PNG
rendering (`test_lockups`, `test_pngopt`, `test_projects`) and reproduce unchanged on
`main` — `rsvg-convert` and `pngquant` are not installed locally. CI installs them
(#62). This change touches no Python.

Part of #53.
