### PR TITLE
docs: distinguish owned channels from borrowed audiences

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,3 +49,15 @@ on a transparent background it is invisible on light surfaces and stray white on
 `profile/README.md`, the landing page GitHub renders at github.com/modern-python. Distinct from the
 **org site**, `modern-python.org`, built from `docs/` — the two carry different content and drift
 apart if the names are used loosely.
+
+**Owned channel**:
+A community surface the org runs, moderates, and is accountable for. GitHub Discussions is the only
+one today, per `docs/adr/0002-discussions-is-the-only-owned-channel.md`.
+_Avoid_: channel, bare. On its own it reads as either kind, and both kinds are linked from the
+profile and the site.
+
+**Borrowed audience**:
+A venue someone else runs, where the org participates as a guest and never moderates: the Python
+Discord, the framework community channels, Stack Overflow, the newsletters.
+_Avoid_: channel — a borrowed audience is never one of ours, and calling it one invites the
+assumption that we moderate it.

--- a/docs/adr/0002-discussions-is-the-only-owned-channel.md
+++ b/docs/adr/0002-discussions-is-the-only-owned-channel.md
@@ -22,6 +22,14 @@ If rooms ever open, the scope is one org-wide room per platform, never per-repo.
 shares one community, and the only rationale that keeps two rooms coherent rather than fragmenting a
 small one is a language/geo split (Russian-speaking Telegram, English/global Discord).
 
+**Borrowing in practice:** a link back to our own pages is conditional, not standing. Link only
+where the linked page actually answers the question at hand (a docs page, or an existing Discussion),
+and never as a bare repo drop. The rejected alternative was a mandatory backlink on every reply: that
+turns participation into the drive-by self-promotion HN, Lobsters and r/Python each punish, and costs
+more standing than the referrals are worth. The obligation that *is* standing runs the other way,
+when a question answered in someone else's venue exposes a gap in our docs, that gap becomes an issue
+here.
+
 **Revisit trigger:** launch week (the work is tracked in modern-python/.github#58). Rooms open *during* it, not before — launch traffic is what seeds
 them past the empty-room threshold. If a room is still inactive 30 days post-launch, fold it back
 into Discussions rather than keeping a dead room linked.


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Why

Triaging #59 turned up a word doing two opposite jobs. ADR-0002 calls Discussions the org's only
**owned channel**, meaning a surface we run and moderate. #59 was titled "Run the borrowed-audience
**channel** program", meaning venues we explicitly do not own. Once #58 links the Telegram and
Discord rooms from every README, the docs sites and the org profile, both senses are live on public
pages at once, and the reader has no way to tell which one a given "channel" means.

The second half is a decision that had no home. #59 was reduced during triage to launch-week work
that can actually close, which meant its standing-participation half went away. The principle it
expressed already lives in ADR-0002 ("borrow audiences before building our own"), but the *conduct*
rule did not exist anywhere: how far the org is obliged to link back when it answers a question in
someone else's venue. That was settled during the grilling and would have been lost with the issue.

## Design

**`CONTEXT.md`** gains two terms, following the file's own bar for inclusion (a synonym to reject, or
a meaning the profile and the site must agree on):

- **Owned channel**: a surface the org runs, moderates, and is accountable for.
- **Borrowed audience**: a venue someone else runs, where the org participates as a guest and never
  moderates.

Both list bare "channel" under `_Avoid_`, which is the actual collision.

**ADR-0002** gains a "Borrowing in practice" paragraph: link back only where the linked page answers
the question at hand, never as a bare repo drop, and when a question answered elsewhere exposes a
docs gap, that gap becomes an issue here. The rejected alternative is recorded with it, a mandatory
backlink on every reply, rejected because it turns participation into exactly the drive-by
self-promotion the launch playbook's etiquette section warns against.

This lands in `docs/adr/` rather than as prose elsewhere because AGENTS.md scopes that directory to
"a rejected alternative, with the reasoning that would otherwise be re-litigated", and gives prose
about mechanism no home at all.

## Non-goals

- **Not superseding ADR-0002's rooms decision.** This addition is purely additive and leaves "no
  Discord server, no Telegram group" standing. #58 still has to supersede that separately, and its
  brief lists the superseding ADR as a deliverable. The two edits will not conflict.
- **Not a new ADR.** The conduct rule is an operational consequence of the principle already in
  ADR-0002, not an independent decision.
- **Not recording the venue list** (Python Discord, framework channels, Stack Overflow). It is
  re-derivable, and AGENTS.md says that means it does not get written.
- **No restructuring of `CONTEXT.md`.** The two terms are appended to the existing flat list; the
  brand vocabulary is untouched.

## Verification

- `uv run pytest`: 123 passed, 26 skipped, 5 failed. All 5 failures are PNG rendering
  (`test_lockups`, `test_pngopt`, `test_projects`) and reproduce identically on `main` at `82cbcc9`.
  They are the local absence of `rsvg-convert`, which CI installs (8c6d117). Nothing here touches
  rendering.
- Both changed files are Markdown outside the built site: `CONTEXT.md` is not in `docs/`, and
  `docs/adr/` is held out of the nav by `not_in_nav` and unpublished since #65. The rendered site is
  therefore unchanged by this PR.

## Related

Produced by the triage of #59, which also retitled that issue, split #72 out of it, and corrected the
scope boundary on #57.
