### PR TITLE
docs: stop restating the admission check in domain.md

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -40,10 +40,7 @@ the project doesn't use (reconsider) or there's a real gap (note it for `/domain
 
 ## Where a new fact goes
 
-Run the admission check in `AGENTS.md` before writing anything down. In short: derivable from the
-source → don't write it; enforceable → a named test with an `INVARIANT:` docstring; a user needs it
-→ `docs/` or `profile/README.md`; a rejected alternative → an ADR; real work you are not doing now →
-a GitHub issue. Nothing else gets written.
+Run the admission check in `AGENTS.md` before writing anything down.
 
 ## Link style inside `docs/`
 


### PR DESCRIPTION
## Why

`docs/agents/domain.md` opens its "Where a new fact goes" section by pointing at the admission check
in `AGENTS.md`, then restates the whole check inline. Two copies of the same rule, and `AGENTS.md`
warns against exactly that two paragraphs below the original ("rots in two places at once").

The pointer stays. Only the restatement goes, so there is one copy of the rule and one signpost to
it.

## Scope, after #77

This PR originally deleted the `## Workflow` and `## Where a fact goes` sections from `AGENTS.md`
as well. #77 landed the alternative treatment of that same material while this branch was being
rebased, condensing `Workflow` and keeping `Where a fact goes` intact. Re-deleting them would revert
that, so the `AGENTS.md` changes are dropped from this PR entirely.

#77 did not touch `docs/agents/domain.md`, so the duplication is untouched by it and is all that
remains here. `AGENTS.md` still carries the admission check this file points at (line 85), so the
pointer resolves.

## Non-goals

`AGENTS.md` is untouched. `docs/agents/issue-tracker.md` and `docs/agents/triage-labels.md` are
untouched: skills read those by path. `domain.md`'s `Link style inside docs/` section stays, being
repo-specific and duplicated nowhere.

## Verification

- `uv run mkdocs build --strict` passes.
- `uv run pytest`: 123 passed, 26 skipped, 5 failed. Those 5 reproduce identically on unmodified
  `main` in a clean worktree; they need `rsvg-convert`, which CI installs and this machine lacks.
