### PR TITLE
docs: cut the Workflow section to what nothing else supplies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,15 +74,13 @@ if it's clean, push a fresh commit to force GitHub to recompute the merge ref.
 ## Workflow
 
 **The spec for a change is its PR body**, not a committed file: why, design,
-non-goals, verification, reviewed with the diff. There is no change file, no lane to
-choose, and no `planning/` tree. A trivial PR (typo, dep bump, formatter, CI tweak)
-ships a conventional-commit title with no body ceremony.
+non-goals, verification, reviewed with the diff. A trivial PR (typo, dep bump,
+formatter, CI tweak) ships a conventional-commit title with no body ceremony.
 
-Two things outlive the PR, and there are exactly two places to put them: an
-alternative **rejected** with reasoning becomes an ADR in [`docs/adr/`](docs/adr/)
-(`NNNN-slug.md`, sequential, with a revisit trigger), and real work **not scheduled**
-becomes a GitHub issue. There is no third state and no truth-home directory — a
-change to a mark, a badge, or a page is reviewed with the diff, not promoted to a page.
+Two things outlive the PR: an alternative **rejected** with reasoning becomes an ADR
+in [`docs/adr/`](docs/adr/), with a revisit trigger, and real work **not scheduled**
+becomes a GitHub issue. Numbering, formats and `gh` usage are in
+[`docs/agents/`](docs/agents/).
 
 ## Where a fact goes
 


### PR DESCRIPTION
## Why

The Workflow section states three things this repo already states elsewhere, and
`AGENTS.md` is loaded on every turn.

**The ADR and issue routes are written twice.** [`docs/agents/domain.md`](docs/agents/domain.md)
already says "a rejected alternative → an ADR; real work you are not doing now → a
GitHub issue. Nothing else gets written", and then points back here for the admission
check. [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md) owns the `gh`
usage. The circularity is the tell.

**`NNNN-slug.md`, sequential** is supplied by the domain-modeling skill's ADR format,
which is what `docs/agents/domain.md` configures. Restating it here means it rots in
two places at once, which is what the same file warns about four sections down.

**"There is no change file, no lane to choose, and no `planning/` tree"** describes
three directories that do not exist. Derivable from the source, therefore not written.
The same goes for "no truth-home directory".

## Design

Cut to what nothing else supplies:

- The body shape (`why, design, non-goals, verification`) stays. No skill defines it;
  it is this org's own convention and the one line with measured effect. PRs #62, #63
  and #65 came out in that shape while this repo's PR template said
  `Summary`/`Changes`/`Checklist`, because `AGENTS.md` is read every turn and the
  template never is.
- The two routes stay as one sentence, because the exactly-two-homes framing is the
  constraint; the numbering and `gh` mechanics become a pointer to `docs/agents/`.
- **"with a revisit trigger" stays.** The skill's ADR format does not include it, so
  it is genuinely this repo's own rule and has no other home.
- The negative clauses go.

Nine lines become seven, and the two duplications become one pointer.

## Non-goals

- **Not removing the revisit-trigger rule.** modern-python/.github#53 decided not to
  propagate it to the other repos. Removing it here is a change to this repo's own ADR
  practice and is a separate call.
- **Not touching `docs/agents/`.** The pointer direction is `AGENTS.md` → `docs/agents/`;
  the reverse pointer in `domain.md` (back here for the admission check) is correct,
  since the admission check has no other home.
- **Not touching the `Where a fact goes` table.** Its `docs/adr/` row overlaps the
  Workflow paragraph, but the table is the admission check itself and is load-bearing.

## Verification

`uv run pytest`: 123 passed, 26 skipped, 5 failed. The five are PNG rendering and
reproduce unchanged on `main` — `rsvg-convert` and `pngquant` are not installed
locally; CI installs them. This change touches no Python.

The one new link, `docs/agents/`, is a directory that exists and is already linked
the same way from this file's Agent skills section. The `links` job (offline lychee
over `**/*.md`) is the gate.
