### PR TITLE
docs: stop asserting the PR-body shape in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,6 @@ if it's clean, push a fresh commit to force GitHub to recompute the merge ref.
 
 ## Workflow
 
-**The spec for a change is its PR body**, not a committed file: why, design,
-non-goals, verification, reviewed with the diff. A trivial PR (typo, dep bump,
-formatter, CI tweak) ships a conventional-commit title with no body ceremony.
-
 Two things outlive the PR: an alternative **rejected** with reasoning becomes an ADR
 in [`docs/adr/`](docs/adr/), with a revisit trigger, and real work **not scheduled**
 becomes a GitHub issue. Numbering, formats and `gh` usage are in


### PR DESCRIPTION
## Why

`AGENTS.md` asserts the PR-body shape — why, design, non-goals, verification — and
that is the last place in the org still doing so. modern-python/modern-di#456,
modern-python/faststream-outbox#168 and modern-python/chat-app#14 drop the same
paragraph. Leaving it here alone means one repo's instructions claim a convention the
others no longer state.

The shape is expected to come from the agent-skills convention rather than from each
repo's `AGENTS.md`, so the file stops asserting it.

## Design

Delete the paragraph. `## Workflow` keeps only the routing that has no other home:
what outlives a PR, and where it goes.

## Non-goals

- **Not touching the routing paragraph.** Its revisit-trigger clause has no other
  home; the numbering and `gh` mechanics already point at `docs/agents/`.
- **Not touching `docs/agents/` or `CONTRIBUTING.md`.** `CONTRIBUTING.md` describes the
  PR workflow for outside human contributors and is a separate audience.

## Verification

`uv run pytest`: 123 passed, 26 skipped, 5 failed. The five are PNG rendering and
reproduce unchanged on `main` — `rsvg-convert` and `pngquant` are not installed
locally; CI installs them. This change touches no Python and removes no link.
