### PR TITLE
docs: drop the org-wide claim from CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,9 +5,6 @@ site at **modern-python.org** from `docs/` (MkDocs Material), and hosts the org
 profile shown on the GitHub org page (`profile/README.md`) plus the community
 health files every other repo inherits.
 
-The conventions in [`AGENTS.md`](AGENTS.md) apply across **all** repos in the org,
-not just this one.
-
 ## Language
 
 A term is listed only when there is a synonym to reject, or a meaning subtle enough that code, the


### PR DESCRIPTION
## Why

`CONTEXT.md` still says the `AGENTS.md` conventions "apply across **all** repos in the
org, not just this one". #73 deleted that exact claim from `AGENTS.md` itself, so the
two files now contradict each other.

The claim is false either way. `AGENTS.md` is not a GitHub default community health
file, so it is never inherited, and no other repo's `AGENTS.md` references this one.
An agent reads the file in the checkout it is standing in.

## Design

Delete the sentence. Nothing replaces it: an agent reading `CONTEXT.md` is already in
this repo and cannot act on a statement about repos it will never see. The paragraph
above it already says what this repo is, including that it hosts the community health
files other repos do inherit.

## Non-goals

- **Not touching the glossary.** No term changes.
- **Not adding a pointer to `CONTRIBUTING.md`.** That file is for outside human
  contributors and already states its own scope.

## Verification

`uv run pytest`: 123 passed, 26 skipped, 5 failed. The five are PNG rendering and
reproduce unchanged on `main` — `rsvg-convert` and `pngquant` are not installed
locally; CI installs them. This change touches no Python and removes no link.
