### PR TITLE
test: skip the PNG assertions when rsvg-convert is absent

### DIFF
--- a/tests/test_lockups.py
+++ b/tests/test_lockups.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 from xml.dom import minidom
 
@@ -28,6 +29,7 @@ def test_render_writes_three_lockup_assets(tmp_path: Path) -> None:
     d = tmp_path / "modern-di"
     assert (d / "lockup-light.svg").is_file()
     assert (d / "lockup-dark.svg").is_file()
-    png = d / "lockup.png"
-    assert png.is_file()
-    assert Image.open(png).mode == "P"  # quantized via export_png
+    if shutil.which("rsvg-convert"):
+        png = d / "lockup.png"
+        assert png.is_file()
+        assert Image.open(png).mode == "P"  # quantized via export_png

--- a/tests/test_pngopt.py
+++ b/tests/test_pngopt.py
@@ -1,8 +1,14 @@
+import shutil
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 from brand.build import projects as p
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("rsvg-convert") is None, reason="rsvg-convert not installed"
+)
 
 
 def _render(tmp: Path) -> None:

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -107,7 +107,8 @@ def test_render_projects_writes_lockup(tmp_path: Path) -> None:
     repo_dir = tmp_path / "modern-di"
     assert (repo_dir / "lockup-light.svg").is_file()
     assert (repo_dir / "lockup-dark.svg").is_file()
-    assert (repo_dir / "lockup.png").is_file()
+    if shutil.which("rsvg-convert"):
+        assert (repo_dir / "lockup.png").is_file()
 
 
 def test_fit_text_shrinks_only_when_needed() -> None:


### PR DESCRIPTION
## Why

`ci.yml` states, above the `librsvg2-bin` install: "Without it every PNG assertion skips itself, so
the version check is what keeps the job from passing empty." That was not true. Five tests **failed**
rather than skipping on a machine without `rsvg-convert`:

- `test_lockups.py::test_render_writes_three_lockup_assets`
- `test_pngopt.py::test_social_card_png_is_quantized_and_small`
- `test_pngopt.py::test_transparent_mark_png_keeps_alpha_and_is_small`
- `test_pngopt.py::test_card_palette_is_actually_reduced`
- `test_projects.py::test_render_projects_writes_lockup`

`export_png` returns `False` and writes nothing when the binary is absent, so these assert on PNGs
that were never produced. The effect is a suite that cannot go green on a contributor's machine
unless they install librsvg first, which nothing tells them to do outside `brand/README.md`.

## Design

No new mechanism: this uses the two patterns the suite already has, picking per test by whether the
test is wholly about PNG output or only partly.

- **`test_pngopt.py` is wholly PNG-dependent** — every test opens a generated PNG — so it takes a
  module-level `pytestmark = pytest.mark.skipif(...)`, the same guard already on
  `test_projects.py::test_no_cream_on_transparent`.
- **`test_lockups.py::test_render_writes_three_lockup_assets` and
  `test_projects.py::test_render_projects_writes_lockup` are mixed**: each asserts two SVGs and then
  a PNG. They take an inline `if shutil.which("rsvg-convert"):` around the PNG half only, the same
  shape used six times in `test_assets.py`. Their SVG assertions keep running everywhere.

Skipping the mixed tests wholesale would have been the smaller diff and the wrong one: it would have
dropped live SVG coverage to fix a PNG problem.

## Non-goals

`brand/build/raster.py` is unchanged. `export_png` returning `False` without the binary is correct
and is what makes the guard meaningful.

Nothing in CI changes. The `rsvg-convert --version` step already fails the job when the binary is
missing, so these guards cannot hollow the job out — that pre-existing check is exactly what makes
skipping safe here, and it is why the comment describing this behaviour was worth making true.

## Verification

Locally, without `rsvg-convert` installed:

| | `main` | this branch |
|---|---|---|
| failed | 5 | 0 |
| passed | 123 | 125 |
| skipped | 26 | 29 |

Passing goes **up**, not down: the three `test_pngopt.py` tests skip (26 → 29), and the two mixed
tests now pass on their SVG assertions instead of failing (123 → 125). No test is disabled.

The with-binary path is what CI exercises, and it is unchanged by construction — every guard is a
`shutil.which` that is truthy there. CI on this PR is the check for that, since the machine this was
written on has no librsvg.
