### PR TITLE
docs(agents): drop the fact-placement convention from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,36 +71,10 @@ if it's clean, push a fresh commit to force GitHub to recompute the merge ref.
 
 ## Workflow
 
-Two things outlive the PR: an alternative **rejected** with reasoning becomes an ADR
-in [`docs/adr/`](docs/adr/), with a revisit trigger, and real work **not scheduled**
-becomes a GitHub issue. Numbering, formats and `gh` usage are in
-[`docs/agents/`](docs/agents/).
+Real work **not scheduled** becomes a GitHub issue.
 
-## Where a fact goes
-
-Four homes, one owner each:
-
-| Home | Holds |
-|---|---|
-| `brand/`, `profile/`, `mkdocs.yml` | anything readable from the source — the default |
-| a named test | an **invariant**: must stay true, and a change could silently break it |
-| `docs/adr/` | a rejected alternative, with the reasoning that would otherwise be re-litigated |
-| `docs/`, `profile/README.md` | anything a user needs |
-
-Before writing a line anywhere:
-
-> Can an agent get this by reading the source? → **don't write it.**
-> Would a wrong change here fail a test? → it belongs **in the test**, not in prose.
-> Does a user need it? → **`docs/`**.
-> Otherwise it does not get written.
-
-**Prose about mechanism has no home. There is no file to add a paragraph to.** This
-file included: it is always loaded, so a line restating a docstring, a justfile
-comment, or `mkdocs.yml` costs every turn and rots in two places at once.
-
-An invariant is a test whose name is the claim, with a docstring opening `INVARIANT:`
-and a second paragraph naming **what breaks it** — design rationale, not a report of
-what this one test catches.
+An invariant is a test whose name is the claim, with a docstring opening `INVARIANT:` and a second
+paragraph naming **what breaks it** — design rationale, not a report of what this one test catches.
 
 ## Agent skills
 


### PR DESCRIPTION
## Why

`AGENTS.md` carried a per-repo copy of a doc-placement convention: a four-homes table, an admission check to run "before writing a line anywhere", an ADR row prescribing `NNNN-slug.md` and revisit triggers, and a ratchet rule.

Doc placement is a domain-modeling convention. Restating it in every repo means ~25 copies that can drift from it, in a file loaded on every turn — the failure the removed text itself named: "it is always loaded, so a line that restates a docstring… costs every turn and rots in two places at once."

The local ADR rule was also weaker than the convention it duplicated: it had no reversibility gate, so any non-obvious rejected alternative qualified.

Piloted and merged in `lite-bootstrap` (#188); this applies the same cut here.

## Design

Removed:

- the `Where a fact goes` section in full — four-homes table, the "before writing a line anywhere" admission check, "prose about mechanism has no home", the ratchet rule
- `Workflow`'s "the spec for a change is its PR body" rule, the "two things outlive the PR" ADR sentence, "there is no change file and no lane to choose", and "there is no separate truth-home directory"
- `Architecture`'s "behaviour detail has no prose home… run the admission check" tail, where present

Kept:

- the `INVARIANT:` docstring shape, with its ADR and lychee clauses trimmed
- one `Workflow` fact: unscheduled work becomes a GitHub issue
- every other section, unchanged
- inline `docs/adr/` citations inside architecture prose. Those cite a specific decision at the point it is relevant; they are not the convention being dropped.

No replacement pointer is added, by design.

## Non-goals

- No ADR is changed, removed or renumbered. `docs/adr/` is untouched.
- No code or test changes.

## Verification

The remaining `docs/adr/` mentions in this file, if any, are inline citations to specific decisions, not a rule about when to write one.
