### PR TITLE
feat(census): check every repo against the standard's core

### DIFF
--- a/.github/scripts/report-census-failure.sh
+++ b/.github/scripts/report-census-failure.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Files the census findings as one open issue: created on the first failure, the body replaced
+# on every later one so the issue always shows the current state, and closed by hand once clean.
+set -euo pipefail
+
+REPORT="${1:?path to the census report}"
+LABEL="census"
+TITLE="Census: repos not meeting the standard's core"
+
+gh label create "$LABEL" --color "FBCA04" --description "Weekly census findings against the standard" --force
+
+body=$(printf '%s\n\n%s\n\n%s\n' \
+  "Weekly census against <https://modern-python.org/standard/>. Latest run: ${RUN_URL}" \
+  "$(cat "$REPORT")" \
+  "Close this issue once a run is clean; the next failing run opens a fresh one.")
+
+existing=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')
+if [ -z "$existing" ]; then
+  gh issue create --title "$TITLE" --label "$LABEL" --body "$body"
+else
+  gh issue edit "$existing" --body "$body"
+  gh issue comment "$existing" --body "Refreshed from ${RUN_URL}"
+fi

--- a/.github/workflows/census.yml
+++ b/.github/workflows/census.yml
@@ -27,20 +27,26 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.11"
+      # Exit 0: clean. Exit 2: findings (the report). Anything else: the census itself broke.
       - name: Run the census
         id: census
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run python -m census --markdown | tee census-report.md
+        run: |
+          set +e
+          uv run python -m census --markdown | tee census-report.md
+          code=${PIPESTATUS[0]}
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          [ "$code" = 0 ] || [ "$code" = 2 ]
       - name: Show the report
+        if: always()
         run: cat census-report.md >> "$GITHUB_STEP_SUMMARY"
       - name: File the tracking issue (scheduled runs only)
-        if: steps.census.outcome == 'failure' && github.event_name == 'schedule'
+        if: steps.census.outputs.code == '2' && github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash .github/scripts/report-census-failure.sh census-report.md
       - name: Fail on findings (scheduled and manual runs; informational on pull requests)
-        if: steps.census.outcome == 'failure' && github.event_name != 'pull_request'
+        if: steps.census.outputs.code == '2' && github.event_name != 'pull_request'
         run: exit 1

--- a/.github/workflows/census.yml
+++ b/.github/workflows/census.yml
@@ -1,0 +1,46 @@
+name: census
+on:
+  pull_request:
+    paths:
+      - "census/**"
+      - "tests/test_census*.py"
+      - "docs/standard.md"
+      - "profile/README.md"
+      - ".github/workflows/census.yml"
+  schedule:
+    - cron: "0 7 * * 1"        # Mondays 07:00 UTC, after the libraries' 06:00 dependency checks
+  workflow_dispatch: {}
+
+concurrency:
+  group: census-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  census:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+      - name: Run the census
+        id: census
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run python -m census --markdown | tee census-report.md
+      - name: Show the report
+        run: cat census-report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: File the tracking issue (scheduled runs only)
+        if: steps.census.outcome == 'failure' && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/report-census-failure.sh census-report.md
+      - name: Fail on findings (scheduled and manual runs; informational on pull requests)
+        if: steps.census.outcome == 'failure' && github.event_name != 'pull_request'
+        run: exit 1

--- a/census/__main__.py
+++ b/census/__main__.py
@@ -6,6 +6,9 @@ import sys
 from census import python_releases, report, rules, snapshot
 
 
+EXIT_FINDINGS = 2
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Check every modern-python repo against the standard's core.")
     parser.add_argument(
@@ -27,7 +30,7 @@ def main() -> int:
         for finding in findings:
             sys.stdout.write(f"{finding.repo}\t{finding.item}\t{finding.message}\n")
         sys.stdout.write(f"{len(findings)} findings across {len(snapshots)} repos\n")
-    return 1 if findings else 0
+    return EXIT_FINDINGS if findings else 0
 
 
 if __name__ == "__main__":

--- a/census/__main__.py
+++ b/census/__main__.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+import pathlib
+import sys
+
+from census import python_releases, report, rules, snapshot
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check every modern-python repo against the standard's core.")
+    parser.add_argument(
+        "--local", type=pathlib.Path, default=None, help="read checkouts under this directory instead of GitHub"
+    )
+    parser.add_argument("--markdown", action="store_true", help="print the findings as Markdown")
+    args = parser.parse_args()
+    local_root = args.local or (pathlib.Path(root) if (root := os.environ.get("CENSUS_LOCAL_ROOT")) else None)
+    snapshots = snapshot.load_from_local(local_root) if local_root else snapshot.load_from_github()
+    profile = pathlib.Path(__file__).resolve().parent.parent / "profile" / "README.md"
+    context = rules.Context(
+        newest_python=python_releases.newest_cycle(),
+        profile_descriptions=report.profile_descriptions(profile),
+    )
+    findings = report.run_census(snapshots, context)
+    if args.markdown:
+        sys.stdout.write(report.render_markdown(findings, len(snapshots)) + "\n")
+    else:
+        for finding in findings:
+            sys.stdout.write(f"{finding.repo}\t{finding.item}\t{finding.message}\n")
+        sys.stdout.write(f"{len(findings)} findings across {len(snapshots)} repos\n")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/census/python_releases.py
+++ b/census/python_releases.py
@@ -1,0 +1,29 @@
+import datetime
+import json
+import os
+import typing
+import urllib.request
+
+
+ENDOFLIFE_URL: typing.Final = "https://endoflife.date/api/python.json"
+
+
+def newest_cycle_from_payload(payload: list[dict[str, typing.Any]], today: datetime.date) -> str:
+    released = [
+        item["cycle"]
+        for item in payload
+        if isinstance(item.get("releaseDate"), str) and datetime.date.fromisoformat(item["releaseDate"]) <= today
+    ]
+    if not released:
+        msg = "endoflife.date returned no released Python cycle"
+        raise ValueError(msg)
+    return max(released, key=lambda cycle: tuple(int(part) for part in cycle.split(".")))
+
+
+def newest_cycle() -> str:
+    if pinned := os.environ.get("CENSUS_NEWEST_PYTHON"):
+        return pinned
+    request = urllib.request.Request(ENDOFLIFE_URL, headers={"User-Agent": "modern-python-census"})
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        payload = json.loads(response.read())
+    return newest_cycle_from_payload(payload, datetime.datetime.now(tz=datetime.UTC).date())

--- a/census/registry.py
+++ b/census/registry.py
@@ -1,0 +1,87 @@
+import typing
+
+
+ORG: typing.Final = "modern-python"
+
+EXCLUDED_REPOS: typing.Final = frozenset({".github"})
+
+SUBSET_REPOS: typing.Final = frozenset(
+    {"fastapi-sqlalchemy-template", "litestar-sqlalchemy-template", "chat-app"},
+)
+
+SUBSET_ITEMS: typing.Final = frozenset(
+    {
+        "claude-md",
+        "agents-paragraphs",
+        "context-md",
+        "license",
+        "ruff-config",
+        "lint-group",
+        "justfile-recipes",
+        "readme-links",
+    },
+)
+
+CORE_ITEMS: typing.Final = SUBSET_ITEMS | frozenset(
+    {
+        "pyproject-metadata",
+        "coverage-gate",
+        "coverage-gate-home",
+        "ci-workflows",
+        "release-workflow",
+        "python-matrix",
+        "description-surfaces",
+        "topics-keywords",
+        "shared-pytest-job",
+    },
+)
+
+EXEMPTIONS: typing.Final[dict[str, frozenset[str]]] = {
+    "that-depends": CORE_ITEMS - {"coverage-gate"},
+    "db-retry": frozenset({"shared-pytest-job"}),
+    "faststream-redis-timers": frozenset({"shared-pytest-job"}),
+    "faststream-concurrent-aiokafka": frozenset({"shared-pytest-job"}),
+    "modern-di-arq": frozenset({"shared-pytest-job"}),
+}
+
+EXTRA_IGNORES: typing.Final[dict[str, frozenset[str]]] = {
+    "faststream-outbox": frozenset({"ANN401"}),
+    "faststream-redis-timers": frozenset({"ANN401"}),
+    "fastapi-sqlalchemy-template": frozenset({"INP", "B008", "S105"}),
+    "litestar-sqlalchemy-template": frozenset({"INP", "B008", "S105"}),
+    "chat-app": frozenset({"INP", "B008", "S105"}),
+}
+
+CANONICAL_IGNORES: typing.Final = frozenset({"D1", "D203", "D213", "COM812", "ISC001", "CPY001", "FBT", "TCH"})
+
+LINT_GROUP_TOOLS: typing.Final = frozenset({"ruff", "ty", "eof-fixer"})
+
+RECIPES: typing.Final = ("install", "lint", "lint-ci", "test", "test-ci", "publish")
+
+CANONICAL_PARAGRAPHS: typing.Final = (
+    (
+        "`just` (task runner) and `uv` (package manager). The [`justfile`](justfile) is the source of truth — "
+        "`just --list`, or read it."
+    ),
+    (
+        "Every link in `README.md` must be absolute: `https://github.com/modern-python/<repo>/blob/main/<path>`, "
+        "or `.../tree/main/<path>` for a directory. Never a relative path: `README.md` is also the PyPI long "
+        "description, and PyPI does not rewrite relative links, so a relative one 404s on the package page."
+    ),
+)
+
+RELEASE_TAG_PATTERNS: typing.Final = frozenset({"[0-9]+.[0-9]+.[0-9]+", "[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+"})
+
+SHARED_CHECKS_WORKFLOW: typing.Final = "modern-python/.github/.github/workflows/checks.yml"
+
+DESCRIPTION_MAX_LENGTH: typing.Final = 120
+TOPICS_MAX: typing.Final = 12
+
+
+def exempted_repos() -> frozenset[str]:
+    return frozenset(EXEMPTIONS) | frozenset(EXTRA_IGNORES)
+
+
+def applicable_items(repo: str) -> frozenset[str]:
+    items = SUBSET_ITEMS if repo in SUBSET_REPOS else CORE_ITEMS
+    return items - EXEMPTIONS.get(repo, frozenset())

--- a/census/report.py
+++ b/census/report.py
@@ -1,0 +1,50 @@
+import dataclasses
+import pathlib
+import re
+import typing
+
+from census import registry, rules
+from census.snapshot import RepoSnapshot
+
+
+_PROFILE_ROW: typing.Final = re.compile(
+    r"^\| \[`(?P<name>[^`]+)`\]\([^)]+\) \| (?P<description>[^|]+?) \|", re.MULTILINE
+)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class Finding:
+    repo: str
+    item: str
+    message: str
+
+
+def profile_descriptions(profile: pathlib.Path) -> dict[str, str]:
+    return {
+        m.group("name"): m.group("description").strip()
+        for m in _PROFILE_ROW.finditer(profile.read_text(encoding="utf-8"))
+    }
+
+
+def run_census(snapshots: typing.Iterable[RepoSnapshot], context: rules.Context) -> list[Finding]:
+    findings = []
+    for snapshot in snapshots:
+        for item in sorted(registry.applicable_items(snapshot.name)):
+            rule = rules.RULES.get(item)
+            if rule is None:
+                continue
+            findings.extend(
+                Finding(repo=snapshot.name, item=item, message=message) for message in rule(snapshot, context)
+            )
+    return findings
+
+
+def render_markdown(findings: typing.Sequence[Finding], repo_count: int) -> str:
+    if not findings:
+        return f"All {repo_count} repos meet the core."
+    lines = [f"{len(findings)} findings across {len({f.repo for f in findings})} of {repo_count} repos.", ""]
+    for repo in sorted({finding.repo for finding in findings}):
+        lines.append(f"### {repo}")
+        lines.extend(f"- **{f.item}**: {f.message}" for f in findings if f.repo == repo)
+        lines.append("")
+    return "\n".join(lines)

--- a/census/rules.py
+++ b/census/rules.py
@@ -1,0 +1,474 @@
+import dataclasses
+import re
+import typing
+
+import tomllib
+import yaml
+
+from census import registry
+from census.snapshot import RepoSnapshot
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class Context:
+    newest_python: str
+    profile_descriptions: typing.Mapping[str, str] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class Recipe:
+    name: str
+    body: tuple[str, ...]
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.body)
+
+
+_RECIPE_HEADER: typing.Final = re.compile(r"^(?P<name>[A-Za-z0-9_-]+)(?P<params>[^:=]*):(?P<deps>.*)$")
+_MARKDOWN_LINK: typing.Final = re.compile(r"\]\((?P<target>[^)\s]+)")
+_HTML_SRC: typing.Final = re.compile(r'(?:src|href)="(?P<target>[^"]+)"')
+_ABSOLUTE: typing.Final = re.compile(r"^(https?://|mailto:|#)")
+_REQUIRES_FLOOR: typing.Final = re.compile(r">=\s*3\.(?P<minor>\d+)")
+_PYTHON_CLASSIFIER: typing.Final = re.compile(r"^Programming Language :: Python :: 3\.(?P<minor>\d+)$")
+_TOPIC: typing.Final = re.compile(r"^[a-z0-9][a-z0-9-]{0,49}$")
+_DEP_NAME: typing.Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def parse_justfile(text: str) -> dict[str, Recipe]:
+    recipes: dict[str, Recipe] = {}
+    current: str | None = None
+    body: list[str] = []
+    for line in text.splitlines():
+        if line.startswith((" ", "\t")):
+            if current is not None:
+                body.append(line.strip())
+            continue
+        if current is not None:
+            recipes[current] = Recipe(name=current, body=tuple(body))
+            current, body = None, []
+        if line.startswith("#") or not line.strip():
+            continue
+        if match := _RECIPE_HEADER.match(line):
+            current = match.group("name")
+    if current is not None:
+        recipes[current] = Recipe(name=current, body=tuple(body))
+    return recipes
+
+
+def normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _pyproject(snapshot: RepoSnapshot) -> dict[str, typing.Any] | None:
+    text = snapshot.read("pyproject.toml")
+    return None if text is None else tomllib.loads(text)
+
+
+def _workflow(snapshot: RepoSnapshot, name: str) -> dict[str, typing.Any] | None:
+    text = snapshot.read(f".github/workflows/{name}")
+    if text is None:
+        return None
+    loaded = yaml.safe_load(text)
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _triggers(workflow: dict[str, typing.Any]) -> typing.Any:  # noqa: ANN401
+    return workflow.get("on", workflow.get(True))
+
+
+def _dep_name(spec: str) -> str:
+    match = _DEP_NAME.match(spec.strip())
+    return match.group(0).lower().replace("_", "-") if match else spec
+
+
+def uses_shared_checks(snapshot: RepoSnapshot) -> bool:
+    workflow = _workflow(snapshot, "ci.yml")
+    if workflow is None:
+        return False
+    return any(
+        str(job.get("uses", "")).startswith(registry.SHARED_CHECKS_WORKFLOW)
+        for job in workflow.get("jobs", {}).values()
+        if isinstance(job, dict)
+    )
+
+
+def check_claude_md(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    text = snapshot.read("CLAUDE.md")
+    if text is None:
+        return ["CLAUDE.md is missing"]
+    if text.strip() != "@AGENTS.md":
+        return ["CLAUDE.md must contain exactly `@AGENTS.md`"]
+    return []
+
+
+def check_agents_paragraphs(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    text = snapshot.read("AGENTS.md")
+    if text is None:
+        return ["AGENTS.md is missing"]
+    normalized = normalize_whitespace(text)
+    return [
+        f"AGENTS.md lacks the canonical paragraph starting `{paragraph[:40]}…`"
+        for paragraph in registry.CANONICAL_PARAGRAPHS
+        if normalize_whitespace(paragraph) not in normalized
+    ]
+
+
+def check_context_md(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    text = snapshot.read("CONTEXT.md")
+    if text is None:
+        return ["CONTEXT.md is missing"]
+    if not text.lstrip().startswith("# "):
+        return ["CONTEXT.md must open with a `# <name>` heading"]
+    return []
+
+
+def check_license(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    text = snapshot.read("LICENSE")
+    if text is None:
+        return ["LICENSE is missing"]
+    if "MIT License" not in text:
+        return ["LICENSE is not the MIT License"]
+    return []
+
+
+def check_lint_group(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    project = _pyproject(snapshot)
+    if project is None:
+        return ["pyproject.toml is missing"]
+    group = project.get("dependency-groups", {}).get("lint")
+    if not isinstance(group, list):
+        return ["pyproject.toml has no `lint` dependency group"]
+    present = {_dep_name(spec) for spec in group if isinstance(spec, str)}
+    return [f"`lint` dependency group lacks {tool}" for tool in sorted(registry.LINT_GROUP_TOOLS - present)]
+
+
+def _ignore_findings(snapshot: RepoSnapshot, lint: dict[str, typing.Any]) -> list[str]:
+    findings = []
+    actual = frozenset(lint.get("ignore", []))
+    allowed_extra = registry.EXTRA_IGNORES.get(snapshot.name, frozenset())
+    if missing := registry.CANONICAL_IGNORES - actual:
+        findings.append(f"ruff ignore list lacks {', '.join(sorted(missing))}")
+    if "S101" in actual:
+        findings.append("S101 must be a `tests/**` per-file ignore, not a global one")
+    if extra := actual - registry.CANONICAL_IGNORES - allowed_extra - {"S101"}:
+        findings.append(f"ruff ignore list carries {', '.join(sorted(extra))} without an exemption")
+    per_file = lint.get("per-file-ignores", {}) | lint.get("extend-per-file-ignores", {})
+    if not any(key.startswith("tests/") and "S101" in rules for key, rules in per_file.items()):
+        findings.append('per-file-ignores lacks `"tests/**" = ["S101"]`')
+    return findings
+
+
+def check_ruff_config(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    project = _pyproject(snapshot)
+    if project is None:
+        return ["pyproject.toml is missing"]
+    ruff = project.get("tool", {}).get("ruff")
+    if ruff is None:
+        return ["pyproject.toml has no [tool.ruff] section"]
+    findings = []
+    expected_top = {"fix": True, "unsafe-fixes": True, "line-length": 120}
+    findings.extend(
+        f"[tool.ruff] {key} must be {value!r}" for key, value in expected_top.items() if ruff.get(key) != value
+    )
+    if "target-version" in ruff:
+        findings.append("[tool.ruff] target-version must be omitted; ruff derives it from requires-python")
+    lint = ruff.get("lint", {})
+    if lint.get("select") != ["ALL"]:
+        findings.append('[tool.ruff.lint] select must be ["ALL"]')
+    findings.extend(_ignore_findings(snapshot, lint))
+    isort = lint.get("isort", {})
+    if isort.get("lines-after-imports") != 2:  # noqa: PLR2004
+        findings.append("[tool.ruff.lint.isort] lines-after-imports must be 2")
+    if isort.get("no-lines-before") != ["standard-library", "local-folder"]:
+        findings.append('[tool.ruff.lint.isort] no-lines-before must be ["standard-library", "local-folder"]')
+    return findings
+
+
+_LINT_STEPS: typing.Final = ("eof-fixer .", "ruff format", "ruff check --fix", "ty check")
+_LINT_CI_STEPS: typing.Final = ("eof-fixer . --check", "ruff format --check", "ruff check --no-fix", "ty check")
+_PUBLISH_STEPS: typing.Final = ("uv version $GITHUB_REF_NAME", "uv build", "uv publish")
+
+
+def _recipe_findings(recipes: dict[str, Recipe], name: str, steps: tuple[str, ...]) -> list[str]:
+    recipe = recipes.get(name)
+    if recipe is None:
+        return []
+    return [f"justfile `{name}` lacks `{step}`" for step in steps if step not in recipe.text]
+
+
+def check_justfile_recipes(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    text = snapshot.read("justfile")
+    if text is None:
+        return ["justfile is missing (lowercase name)"]
+    recipes = parse_justfile(text)
+    required = (
+        registry.RECIPES
+        if snapshot.name not in registry.SUBSET_REPOS
+        else tuple(r for r in registry.RECIPES if r != "publish")
+    )
+    findings = [f"justfile lacks recipe `{name}`" for name in required if name not in recipes]
+    findings.extend(_recipe_findings(recipes, "lint", _LINT_STEPS))
+    findings.extend(_recipe_findings(recipes, "lint-ci", _LINT_CI_STEPS))
+    findings.extend(_recipe_findings(recipes, "publish", _PUBLISH_STEPS))
+    if (publish := recipes.get("publish")) and "--token" in publish.text:
+        findings.append("justfile `publish` must not pass a token; auth is Trusted Publishing")
+    if (test := recipes.get("test")) and (
+        "pytest" not in test.text or "{{ args }}" not in test.text.replace("{{args}}", "{{ args }}")
+    ):
+        findings.append("justfile `test` must run pytest and pass `{{ args }}` through")
+    return findings
+
+
+def _coverage_fail_under(project: dict[str, typing.Any]) -> object:
+    coverage = project.get("tool", {}).get("coverage", {})
+    return coverage.get("report", {}).get("fail_under")
+
+
+def _pytest_addopts_gate(project: dict[str, typing.Any]) -> bool:
+    addopts = project.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("addopts", "")
+    return "--cov-fail-under=100" in (addopts if isinstance(addopts, str) else " ".join(addopts))
+
+
+def check_coverage_gate(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    project = _pyproject(snapshot) or {}
+    recipes = parse_justfile(snapshot.read("justfile") or "")
+    in_justfile = any("--cov-fail-under=100" in recipe.text for recipe in recipes.values())
+    in_pyproject = _coverage_fail_under(project) == 100 or _pytest_addopts_gate(project)  # noqa: PLR2004
+    return [] if in_justfile or in_pyproject else ["no 100% coverage gate anywhere"]
+
+
+def check_coverage_gate_home(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    findings = []
+    project = _pyproject(snapshot) or {}
+    if _coverage_fail_under(project) is not None:
+        findings.append("[tool.coverage.report] fail_under is set; the gate lives in `just test-ci` only")
+    if _pytest_addopts_gate(project):
+        findings.append("pytest addopts gate coverage on every run; the gate lives in `just test-ci` only")
+    recipes = parse_justfile(snapshot.read("justfile") or "")
+    if (test := recipes.get("test")) and "cov-fail-under" in test.text:
+        findings.append("justfile `test` must not gate coverage")
+    if (test_ci := recipes.get("test-ci")) and "--cov-fail-under=100" not in test_ci.text:
+        findings.append("justfile `test-ci` must pass `--cov-fail-under=100`")
+    return findings
+
+
+def _metadata_project_findings(snapshot: RepoSnapshot, project: dict[str, typing.Any]) -> list[str]:
+    findings = []
+    meta = project.get("project", {})
+    if meta.get("name") != snapshot.name:
+        findings.append(f"[project] name must equal the repo name `{snapshot.name}`")
+    if meta.get("version") != "0":
+        findings.append('[project] version must be "0"; the tag sets the real one')
+    if meta.get("license") != "MIT":
+        findings.append('[project] license must be the SPDX string "MIT"')
+    if project.get("build-system", {}).get("build-backend") != "uv_build":
+        findings.append("[build-system] build-backend must be uv_build")
+    description = meta.get("description", "")
+    if not description:
+        findings.append("[project] description is missing")
+    elif len(description) > registry.DESCRIPTION_MAX_LENGTH or description.endswith("."):
+        findings.append("[project] description must be at most 120 characters with no trailing period")
+    if not meta.get("keywords"):
+        findings.append("[project] keywords are missing")
+    return findings
+
+
+def check_pyproject_metadata(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    project = _pyproject(snapshot)
+    if project is None:
+        return ["pyproject.toml is missing"]
+    findings = _metadata_project_findings(snapshot, project)
+    meta = project.get("project", {})
+    classifiers = meta.get("classifiers", [])
+    for needle in ("Intended Audience :: Developers", "Typing :: Typed"):
+        if needle not in classifiers:
+            findings.append(f"classifiers lack `{needle}`")
+    if not any(item.startswith("Development Status ::") for item in classifiers):
+        findings.append("classifiers lack a `Development Status ::` entry")
+    if any(item.startswith("License ::") for item in classifiers):
+        findings.append("classifiers must not carry a `License ::` entry (PEP 639)")
+    urls = meta.get("urls", {})
+    expected_urls = {
+        "Homepage": None,
+        "Repository": f"https://github.com/{registry.ORG}/{snapshot.name}",
+        "Issues": f"https://github.com/{registry.ORG}/{snapshot.name}/issues",
+        "Changelog": f"https://github.com/{registry.ORG}/{snapshot.name}/releases",
+    }
+    for label, expected in expected_urls.items():
+        if label not in urls:
+            findings.append(f"[project.urls] lacks `{label}`")
+        elif expected is not None and urls[label] != expected:
+            findings.append(f"[project.urls] {label} must be {expected}")
+    return findings
+
+
+def check_ci_workflows(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    findings = []
+    ci = _workflow(snapshot, "ci.yml")
+    if ci is None:
+        findings.append("ci.yml is missing")
+    else:
+        triggers = _triggers(ci) or {}
+        if not isinstance(triggers, dict) or "pull_request" not in triggers or "push" not in triggers:
+            findings.append("ci.yml must trigger on pull_request and push")
+        if "concurrency" not in ci:
+            findings.append("ci.yml must declare `concurrency` to cancel superseded runs")
+    scheduled = _workflow(snapshot, "scheduled.yml")
+    if scheduled is None:
+        findings.append("scheduled.yml is missing")
+    elif not isinstance(triggers := _triggers(scheduled), dict) or "schedule" not in triggers:
+        findings.append("scheduled.yml must trigger on a schedule")
+    if "publish.yml" in snapshot.workflow_names():
+        findings.append("publish.yml is the retired release-published trigger; release.yml replaces it")
+    if not uses_shared_checks(snapshot):
+        checks = _workflow(snapshot, "_checks.yml")
+        if checks is None:
+            findings.append("neither the shared checks workflow nor a local _checks.yml is used")
+        else:
+            jobs = set(checks.get("jobs", {}))
+            findings.extend(
+                f"_checks.yml lacks the `{job}` job" for job in ("lint", "pytest", "links") if job not in jobs
+            )
+    return findings
+
+
+def check_release_workflow(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    release = _workflow(snapshot, "release.yml")
+    if release is None:
+        return ["release.yml is missing"]
+    findings = []
+    triggers = _triggers(release) or {}
+    tags = frozenset((triggers.get("push") or {}).get("tags") or []) if isinstance(triggers, dict) else frozenset()
+    if tags != registry.RELEASE_TAG_PATTERNS:
+        findings.append("release.yml must trigger on exactly the stable and pre-release tag patterns")
+    permissions = release.get("permissions", {})
+    if permissions.get("id-token") != "write" or permissions.get("contents") != "write":
+        findings.append("release.yml must grant `id-token: write` and `contents: write`")
+    jobs = [job for job in release.get("jobs", {}).values() if isinstance(job, dict)]
+    if not any(job.get("environment") == "pypi" for job in jobs):
+        findings.append("release.yml must run in the `pypi` environment")
+    steps = [step for job in jobs for step in job.get("steps", []) if isinstance(step, dict)]
+    if not any("just publish" in str(step.get("run", "")) for step in steps):
+        findings.append("release.yml must run `just publish`")
+    return findings
+
+
+def _matrix_versions(checks: dict[str, typing.Any]) -> tuple[set[str], list[str]]:
+    versions: set[str] = set()
+    unquoted: list[str] = []
+    for job in checks.get("jobs", {}).values():
+        if not isinstance(job, dict):
+            continue
+        matrix = job.get("strategy", {}).get("matrix", {})
+        candidates = list(matrix.get("python-version", []) or [])
+        candidates.extend(entry.get("python-version") for entry in matrix.get("include", []) if isinstance(entry, dict))
+        for candidate in candidates:
+            if isinstance(candidate, float):
+                unquoted.append(str(candidate))
+            elif candidate is not None:
+                versions.add(str(candidate))
+    return versions, unquoted
+
+
+def check_python_matrix(snapshot: RepoSnapshot, context: Context) -> list[str]:
+    project = _pyproject(snapshot)
+    if project is None:
+        return ["pyproject.toml is missing"]
+    requires = project.get("project", {}).get("requires-python", "")
+    floor_match = _REQUIRES_FLOOR.search(requires)
+    if floor_match is None:
+        return ["requires-python must declare a `>=3.X` floor"]
+    newest_minor = int(context.newest_python.split(".")[1])
+    expected = {f"3.{minor}" for minor in range(int(floor_match.group("minor")), newest_minor + 1)}
+    findings = []
+    classifiers = {
+        f"3.{match.group('minor')}"
+        for item in project.get("project", {}).get("classifiers", [])
+        if (match := _PYTHON_CLASSIFIER.match(item))
+    }
+    if classifiers != expected:
+        findings.append(f"Python classifiers must list exactly {', '.join(sorted(expected))}")
+    if uses_shared_checks(snapshot):
+        return findings
+    checks = _workflow(snapshot, "_checks.yml")
+    if checks is None:
+        return [*findings, "_checks.yml is missing; the matrix cannot be checked"]
+    versions, unquoted = _matrix_versions(checks)
+    if unquoted:
+        findings.append(f"matrix python-version entries must be quoted strings; found {', '.join(unquoted)}")
+    if missing := expected - versions:
+        findings.append(f"pytest matrix lacks {', '.join(sorted(missing))}")
+    if f"{context.newest_python}t" not in versions:
+        findings.append(f"pytest matrix lacks the free-threaded build {context.newest_python}t")
+    return findings
+
+
+def _readme(snapshot: RepoSnapshot) -> str | None:
+    return next((text for path, text in snapshot.files.items() if path.lower() == "readme.md"), None)
+
+
+def check_readme_links(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    text = _readme(snapshot)
+    if text is None:
+        return ["README.md is missing"]
+    targets = [match.group("target") for match in _MARKDOWN_LINK.finditer(text)]
+    targets.extend(match.group("target") for match in _HTML_SRC.finditer(text))
+    relative = sorted({target for target in targets if not _ABSOLUTE.match(target)})
+    return [f"README.md has a relative link: {target}" for target in relative]
+
+
+def check_description_surfaces(snapshot: RepoSnapshot, context: Context) -> list[str]:
+    if snapshot.description is None:
+        return []
+    project = _pyproject(snapshot) or {}
+    findings = []
+    pyproject_description = project.get("project", {}).get("description")
+    if pyproject_description != snapshot.description:
+        findings.append("GitHub description and pyproject description differ")
+    profile_description = context.profile_descriptions.get(snapshot.name)
+    if profile_description is None:
+        findings.append("repo has no row in the org profile")
+    elif profile_description != snapshot.description:
+        findings.append("GitHub description and org profile row differ")
+    return findings
+
+
+def check_topics_keywords(snapshot: RepoSnapshot, _: Context) -> list[str]:
+    if snapshot.topics is None:
+        return []
+    findings = []
+    if not snapshot.topics:
+        findings.append("repo has no GitHub topics")
+    if len(snapshot.topics) > registry.TOPICS_MAX:
+        findings.append(f"repo has more than {registry.TOPICS_MAX} topics")
+    findings.extend(
+        f"topic `{topic}` is not lowercase-hyphenated" for topic in snapshot.topics if not _TOPIC.match(topic)
+    )
+    project = _pyproject(snapshot) or {}
+    keywords = frozenset(project.get("project", {}).get("keywords", []))
+    if keywords != frozenset(snapshot.topics):
+        findings.append("pyproject keywords and GitHub topics differ")
+    if not snapshot.homepage:
+        findings.append("repo website field is empty; set the docs site or modern-python.org")
+    return findings
+
+
+RULES: typing.Final[dict[str, typing.Callable[[RepoSnapshot, Context], list[str]]]] = {
+    "claude-md": check_claude_md,
+    "agents-paragraphs": check_agents_paragraphs,
+    "context-md": check_context_md,
+    "license": check_license,
+    "lint-group": check_lint_group,
+    "ruff-config": check_ruff_config,
+    "justfile-recipes": check_justfile_recipes,
+    "coverage-gate": check_coverage_gate,
+    "coverage-gate-home": check_coverage_gate_home,
+    "pyproject-metadata": check_pyproject_metadata,
+    "ci-workflows": check_ci_workflows,
+    "release-workflow": check_release_workflow,
+    "python-matrix": check_python_matrix,
+    "readme-links": check_readme_links,
+    "description-surfaces": check_description_surfaces,
+    "topics-keywords": check_topics_keywords,
+}

--- a/census/snapshot.py
+++ b/census/snapshot.py
@@ -1,0 +1,128 @@
+import dataclasses
+import io
+import json
+import os
+import pathlib
+import re
+import subprocess
+import tarfile
+import typing
+import urllib.request
+
+from census import registry
+
+
+MAX_TEXT_FILE_BYTES: typing.Final = 512 * 1024
+_REMOTE_NAME: typing.Final = re.compile(r"modern-python/(?P<name>[^/\s]+?)(?:\.git)?\s*$")
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class RepoSnapshot:
+    name: str
+    files: typing.Mapping[str, str]
+    description: str | None = None
+    topics: tuple[str, ...] | None = None
+    homepage: str | None = None
+
+    def read(self, path: str) -> str | None:
+        return self.files.get(path)
+
+    def has_dir(self, prefix: str) -> bool:
+        wanted = prefix.rstrip("/") + "/"
+        return any(path.startswith(wanted) for path in self.files)
+
+    def workflow_names(self) -> frozenset[str]:
+        prefix = ".github/workflows/"
+        return frozenset(path.removeprefix(prefix) for path in self.files if path.startswith(prefix))
+
+
+def github_token() -> str | None:
+    if token := os.environ.get("GITHUB_TOKEN"):
+        return token
+    try:
+        return subprocess.run(["gh", "auth", "token"], check=True, capture_output=True, text=True).stdout.strip()  # noqa: S607
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _get(url: str, token: str | None) -> bytes:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "modern-python-census"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)  # noqa: S310
+    with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310
+        return response.read()
+
+
+def _files_from_tarball(payload: bytes) -> dict[str, str]:
+    files: dict[str, str] = {}
+    with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+        for member in archive:
+            if not member.isfile() or member.size > MAX_TEXT_FILE_BYTES:
+                continue
+            path = member.name.split("/", 1)[1] if "/" in member.name else member.name
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                continue
+            try:
+                files[path] = extracted.read().decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+    return files
+
+
+def load_from_github(token: str | None = None) -> list[RepoSnapshot]:
+    token = token or github_token()
+    listing = json.loads(_get(f"https://api.github.com/orgs/{registry.ORG}/repos?per_page=100&type=public", token))
+    snapshots = []
+    for repo in sorted(listing, key=lambda item: item["name"]):
+        if repo["archived"] or repo["name"] in registry.EXCLUDED_REPOS:
+            continue
+        tarball = _get(
+            f"https://api.github.com/repos/{registry.ORG}/{repo['name']}/tarball/{repo['default_branch']}", token
+        )
+        snapshots.append(
+            RepoSnapshot(
+                name=repo["name"],
+                files=_files_from_tarball(tarball),
+                description=repo.get("description"),
+                topics=tuple(repo.get("topics") or ()),
+                homepage=repo.get("homepage") or None,
+            ),
+        )
+    return snapshots
+
+
+def _remote_name(checkout: pathlib.Path) -> str | None:
+    config = checkout / ".git" / "config"
+    if not config.is_file():
+        return None
+    for line in config.read_text(encoding="utf-8").splitlines():
+        if "url" in line and (match := _REMOTE_NAME.search(line)):
+            return match.group("name")
+    return None
+
+
+def _files_from_checkout(checkout: pathlib.Path) -> dict[str, str]:
+    files: dict[str, str] = {}
+    skipped_dirs = {".git", ".venv", "node_modules", "__pycache__", ".ruff_cache", ".pytest_cache", "site"}
+    for path in checkout.rglob("*"):
+        if not path.is_file() or skipped_dirs & set(path.relative_to(checkout).parts):
+            continue
+        if path.stat().st_size > MAX_TEXT_FILE_BYTES:
+            continue
+        try:
+            files[path.relative_to(checkout).as_posix()] = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+    return files
+
+
+def load_from_local(root: pathlib.Path) -> list[RepoSnapshot]:
+    snapshots = []
+    for checkout in sorted(root.iterdir()):
+        name = _remote_name(checkout)
+        if name is None or name in registry.EXCLUDED_REPOS:
+            continue
+        snapshots.append(RepoSnapshot(name=name, files=_files_from_checkout(checkout)))
+    return snapshots

--- a/justfile
+++ b/justfile
@@ -14,6 +14,6 @@ sync-assets:
 census:
     uv run pytest -m census -p no:cacheprovider
 
-# Same census as a Markdown report, exit 1 on findings; the weekly workflow files it as an issue.
+# Same census as a Markdown report; exit 2 on findings (1 means the census itself broke). The weekly workflow files it as an issue.
 census-report:
     uv run python -m census --markdown

--- a/justfile
+++ b/justfile
@@ -8,3 +8,12 @@ sync-assets:
     uv run python -m brand.build.render
     cp brand/org/favicon.svg brand/org/mark.svg brand/org/wordmark.svg brand/org/wordmark-dark.svg docs/assets/
     cp brand/org/social-card-green.png docs/assets/
+
+# Check every org repo against the standard's core (network: GitHub API + endoflife.date).
+# CENSUS_LOCAL_ROOT=~/src/modern-python reads local checkouts instead.
+census:
+    uv run pytest -m census -p no:cacheprovider
+
+# Same census as a Markdown report, exit 1 on findings; the weekly workflow files it as an issue.
+census-report:
+    uv run python -m census --markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,11 @@ dev = [
     "fonttools>=4.63.0",
     "pillow>=11.0.0",
     "pytest>=9.1.1",
+    "pyyaml>=6.0",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+addopts = "-m 'not census'"
+markers = ["census: reads every org repo over the network; run with `just census`"]

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -1,0 +1,23 @@
+import os
+import pathlib
+
+import pytest
+
+from census import python_releases, report, rules, snapshot
+
+
+pytestmark = pytest.mark.census
+
+
+def test_every_repo_meets_the_core() -> None:
+    local_root = os.environ.get("CENSUS_LOCAL_ROOT")
+    snapshots = snapshot.load_from_local(pathlib.Path(local_root)) if local_root else snapshot.load_from_github()
+    assert snapshots, "no repos loaded"
+    context = rules.Context(
+        newest_python=python_releases.newest_cycle(),
+        profile_descriptions=report.profile_descriptions(
+            pathlib.Path(__file__).parent.parent / "profile" / "README.md"
+        ),
+    )
+    findings = report.run_census(snapshots, context)
+    assert not findings, "\n" + report.render_markdown(findings, len(snapshots))

--- a/tests/test_census_cli.py
+++ b/tests/test_census_cli.py
@@ -1,0 +1,38 @@
+import pathlib
+
+import pytest
+
+from census import __main__ as cli
+from tests.test_census_rules import _COMPLIANT_FILES
+
+
+def _checkout(root: pathlib.Path, files: dict[str, str]) -> None:
+    repo = root / "demo-lib"
+    (repo / ".git").mkdir(parents=True)
+    (repo / ".git" / "config").write_text('[remote "origin"]\n\turl = git@github.com:modern-python/demo-lib.git\n')
+    for path, text in files.items():
+        target = repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_exit"),
+    [({}, 0), ({"CLAUDE.md": "# not the pointer\n"}, cli.EXIT_FINDINGS)],
+)
+def test_cli_exit_code_distinguishes_findings_from_success(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    overrides: dict[str, str],
+    expected_exit: int,
+) -> None:
+    _checkout(tmp_path, {**_COMPLIANT_FILES, **overrides})
+    monkeypatch.setenv("CENSUS_NEWEST_PYTHON", "3.14")
+    monkeypatch.setattr("sys.argv", ["census", "--local", str(tmp_path), "--markdown"])
+    assert cli.main() == expected_exit
+    assert "1 repos" in capsys.readouterr().out
+
+
+def test_findings_exit_code_is_not_the_crash_exit_code() -> None:
+    assert cli.EXIT_FINDINGS != 1

--- a/tests/test_census_registry.py
+++ b/tests/test_census_registry.py
@@ -1,0 +1,44 @@
+import pathlib
+import re
+
+from census import registry, rules
+
+
+_STANDARD = pathlib.Path(__file__).parent.parent / "docs" / "standard.md"
+_ROW_NAMES = re.compile(r"`([a-z0-9-]+)`")
+
+
+def _exemption_table_repos() -> frozenset[str]:
+    section = _STANDARD.read_text(encoding="utf-8").split("## Exemptions", 1)[1].split("## ", 1)[0]
+    rows = [line for line in section.splitlines() if line.startswith("| `")]
+    return frozenset(name for row in rows for name in _ROW_NAMES.findall(row.split("|")[1]))
+
+
+def test_registry_and_standard_list_the_same_exempt_repos() -> None:
+    """INVARIANT: every repo the census exempts has a row in the standard's Exemptions table, and vice versa.
+
+    The registry is what the census honours; the table is what a reader sees. An exemption added to
+    one and not the other is either silently unenforced or silently undocumented.
+    """
+    assert _exemption_table_repos() == registry.exempted_repos()
+
+
+def test_every_exemption_names_a_known_item() -> None:
+    known = registry.CORE_ITEMS
+    for repo, items in registry.EXEMPTIONS.items():
+        assert items <= known, f"{repo} is exempt from unknown items {items - known}"
+
+
+def test_every_core_item_has_a_rule_or_is_a_placeholder() -> None:
+    assert registry.CORE_ITEMS - set(rules.RULES) == {"shared-pytest-job"}
+
+
+def test_canonical_paragraphs_match_the_standard() -> None:
+    text = rules.normalize_whitespace(_STANDARD.read_text(encoding="utf-8"))
+    for paragraph in registry.CANONICAL_PARAGRAPHS:
+        assert rules.normalize_whitespace(paragraph) in text
+
+
+def test_canonical_ignores_match_the_standard() -> None:
+    block = _STANDARD.read_text(encoding="utf-8").split("ignore = [", 1)[1].split("]", 1)[0]
+    assert frozenset(re.findall(r'"([A-Z0-9]+)"', block)) == registry.CANONICAL_IGNORES

--- a/tests/test_census_rules.py
+++ b/tests/test_census_rules.py
@@ -1,0 +1,365 @@
+import datetime
+import pathlib
+
+import pytest
+
+from census import python_releases, registry, report, rules
+from census.snapshot import RepoSnapshot
+
+
+_PYPROJECT = """
+[project]
+name = "demo-lib"
+version = "0"
+description = "Does one thing well"
+license = "MIT"
+requires-python = ">=3.12,<4"
+keywords = ["python", "demo"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://modern-python.org"
+Repository = "https://github.com/modern-python/demo-lib"
+Issues = "https://github.com/modern-python/demo-lib/issues"
+Changelog = "https://github.com/modern-python/demo-lib/releases"
+
+[build-system]
+requires = ["uv_build>=0.11,<1.0"]
+build-backend = "uv_build"
+
+[dependency-groups]
+dev = ["pytest", "pytest-cov"]
+lint = ["ruff", "ty", "eof-fixer"]
+
+[tool.ruff]
+fix = true
+unsafe-fixes = true
+line-length = 120
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["D1", "D203", "D213", "COM812", "ISC001", "CPY001", "FBT", "TCH"]
+isort.lines-after-imports = 2
+isort.no-lines-before = ["standard-library", "local-folder"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101"]
+"""
+
+_JUSTFILE = """default: install lint test
+
+install:
+    uv lock --upgrade
+    uv sync --all-extras --frozen --group lint
+
+lint:
+    uv run eof-fixer .
+    uv run ruff format
+    uv run ruff check --fix
+    uv run ty check
+
+lint-ci:
+    uv run eof-fixer . --check
+    uv run ruff format --check
+    uv run ruff check --no-fix
+    uv run ty check
+
+test *args:
+    uv run --no-sync pytest {{ args }}
+
+test-ci:
+    uv run --no-sync pytest --cov=. --cov-report term-missing --cov-report xml --cov-fail-under=100
+
+# Auth via PyPI Trusted Publishing (OIDC).
+publish:
+    rm -rf dist
+    uv version $GITHUB_REF_NAME
+    uv build
+    uv publish
+"""
+
+_CI = """name: main
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+"""
+
+_CHECKS = """name: checks
+on:
+  workflow_call: {}
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps: []
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14", "3.14t"]
+    steps: []
+  links:
+    runs-on: ubuntu-latest
+    steps: []
+"""
+
+_SCHEDULED = """name: scheduled
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+"""
+
+_RELEASE = """name: Release
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+'
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - run: just publish
+"""
+
+_AGENTS = """# AGENTS.md
+
+`just` (task runner) and `uv` (package manager). The [`justfile`](justfile) is the source of
+truth — `just --list`, or read it. The one thing it does not say: nothing.
+
+Every link in `README.md` must be absolute: `https://github.com/modern-python/<repo>/blob/main/<path>`,
+or `.../tree/main/<path>` for a directory. Never a relative path: `README.md` is also the PyPI long
+description, and PyPI does not rewrite relative links, so a relative one 404s on the package page.
+"""
+
+_COMPLIANT_FILES = {
+    "pyproject.toml": _PYPROJECT,
+    "justfile": _JUSTFILE,
+    "CLAUDE.md": "@AGENTS.md\n",
+    "AGENTS.md": _AGENTS,
+    "CONTEXT.md": "# demo-lib\n\nDoes one thing well.\n",
+    "LICENSE": "MIT License\n\nCopyright (c) 2026\n",
+    "README.md": "# demo-lib\n\nSee [docs](https://github.com/modern-python/demo-lib/blob/main/docs/index.md).\n",
+    ".github/workflows/ci.yml": _CI,
+    ".github/workflows/_checks.yml": _CHECKS,
+    ".github/workflows/scheduled.yml": _SCHEDULED,
+    ".github/workflows/release.yml": _RELEASE,
+}
+
+_CONTEXT = rules.Context(newest_python="3.14", profile_descriptions={"demo-lib": "Does one thing well"})
+
+
+def _snapshot(**overrides: str | None) -> RepoSnapshot:
+    files = {path: text for path, text in {**_COMPLIANT_FILES, **overrides}.items() if text is not None}
+    return RepoSnapshot(
+        name="demo-lib",
+        files=files,
+        description="Does one thing well",
+        topics=("python", "demo"),
+        homepage="https://modern-python.org",
+    )
+
+
+def test_compliant_repo_has_no_findings() -> None:
+    assert report.run_census([_snapshot()], _CONTEXT) == []
+
+
+@pytest.mark.parametrize(
+    ("path", "content", "item", "fragment"),
+    [
+        ("CLAUDE.md", "# Notes\n", "claude-md", "exactly"),
+        ("CLAUDE.md", None, "claude-md", "missing"),
+        ("AGENTS.md", "# AGENTS.md\n\nnothing canonical here\n", "agents-paragraphs", "canonical paragraph"),
+        ("CONTEXT.md", None, "context-md", "missing"),
+        ("LICENSE", "Apache License\n", "license", "MIT"),
+        ("README.md", '[guide](docs/guide.md) and <img src="logo.svg">', "readme-links", "relative link"),
+        (".github/workflows/scheduled.yml", None, "ci-workflows", "scheduled.yml"),
+        (".github/workflows/publish.yml", "on: release\njobs: {}\n", "ci-workflows", "publish.yml"),
+        (
+            ".github/workflows/release.yml",
+            _RELEASE.replace("environment: pypi", "environment: prod"),
+            "release-workflow",
+            "pypi",
+        ),
+        (".github/workflows/_checks.yml", _CHECKS.replace(', "3.14t"', ""), "python-matrix", "free-threaded"),
+        (".github/workflows/_checks.yml", _CHECKS.replace('"3.13", ', ""), "python-matrix", "lacks 3.13"),
+        (".github/workflows/_checks.yml", _CHECKS.replace('"3.12"', "3.12"), "python-matrix", "quoted"),
+    ],
+)
+def test_single_file_deviation_is_reported(path: str, content: str | None, item: str, fragment: str) -> None:
+    findings = report.run_census([_snapshot(**{path: content})], _CONTEXT)
+    assert {f.item for f in findings} == {item}
+    assert any(fragment in f.message for f in findings)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "item", "fragment"),
+    [
+        ('"TCH"]', '"TCH", "G004"]', "ruff-config", "G004"),
+        ('"TCH"]', '"TCH", "S101"]', "ruff-config", "S101 must be"),
+        ('"D1", ', "", "ruff-config", "lacks D1"),
+        ("line-length = 120", "line-length = 100", "ruff-config", "line-length"),
+        ("line-length = 120", 'line-length = 120\ntarget-version = "py312"', "ruff-config", "target-version"),
+        ('lint = ["ruff", "ty", "eof-fixer"]', 'lint = ["ruff", "ty"]', "lint-group", "eof-fixer"),
+        ('version = "0"', 'version = "1.2.3"', "pyproject-metadata", "version"),
+        (
+            '"Typing :: Typed",',
+            '"Typing :: Typed",\n    "License :: OSI Approved :: MIT License",',
+            "pyproject-metadata",
+            "License ::",
+        ),
+        ('license = "MIT"', 'license = "Apache-2.0"', "pyproject-metadata", "SPDX"),
+        ('Changelog = "https://github.com/modern-python/demo-lib/releases"', "", "pyproject-metadata", "Changelog"),
+        ('    "Programming Language :: Python :: 3.12",\n', "", "python-matrix", "classifiers"),
+    ],
+)
+def test_pyproject_deviation_is_reported(old: str, new: str, item: str, fragment: str) -> None:
+    assert old in _PYPROJECT
+    findings = report.run_census([_snapshot(**{"pyproject.toml": _PYPROJECT.replace(old, new)})], _CONTEXT)
+    assert {f.item for f in findings} == {item}
+    assert any(fragment in f.message for f in findings)
+
+
+def test_trailing_period_in_description_is_reported_on_both_surfaces() -> None:
+    pyproject = _PYPROJECT.replace('description = "Does one thing well"', 'description = "Does one thing well."')
+    findings = report.run_census([_snapshot(**{"pyproject.toml": pyproject})], _CONTEXT)
+    assert {f.item for f in findings} == {"pyproject-metadata", "description-surfaces"}
+    assert any("trailing period" in f.message for f in findings)
+
+
+def test_coverage_gate_in_pyproject_is_the_wrong_home() -> None:
+    pyproject = _PYPROJECT + "\n[tool.coverage.report]\nfail_under = 100\n"
+    justfile = _JUSTFILE.replace(" --cov-fail-under=100", "")
+    findings = report.run_census([_snapshot(**{"pyproject.toml": pyproject, "justfile": justfile})], _CONTEXT)
+    assert {f.item for f in findings} == {"coverage-gate-home"}
+    assert len(findings) == 2  # noqa: PLR2004
+
+
+def test_missing_gate_everywhere_is_two_findings() -> None:
+    justfile = _JUSTFILE.replace(" --cov-fail-under=100", "")
+    findings = report.run_census([_snapshot(justfile=justfile)], _CONTEXT)
+    assert {f.item for f in findings} == {"coverage-gate", "coverage-gate-home"}
+
+
+def test_justfile_recipe_contracts() -> None:
+    justfile = _JUSTFILE.replace("uv run ruff check --no-fix\n", "").replace(
+        "uv publish", "uv publish --token $PYPI_TOKEN"
+    )
+    findings = report.run_census([_snapshot(justfile=justfile)], _CONTEXT)
+    messages = [f.message for f in findings if f.item == "justfile-recipes"]
+    assert any("lint-ci" in m and "ruff check --no-fix" in m for m in messages)
+    assert any("token" in m for m in messages)
+
+
+def test_justfile_parser_handles_dependencies_and_comments() -> None:
+    recipes = rules.parse_justfile(
+        "# comment\n"
+        "test *args: down && down\n"
+        "    docker compose run app uv run pytest {{ args }}\n"
+        "\n"
+        "build:\n"
+        "    docker compose build\n",
+    )
+    assert set(recipes) == {"test", "build"}
+    assert "pytest {{ args }}" in recipes["test"].text
+
+
+def test_exempted_extra_ignore_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(registry.EXTRA_IGNORES, "demo-lib", frozenset({"ANN401"}))
+    pyproject = _PYPROJECT.replace('"TCH"]', '"TCH", "ANN401"]')
+    assert report.run_census([_snapshot(**{"pyproject.toml": pyproject})], _CONTEXT) == []
+
+
+def test_subset_repo_skips_library_only_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(registry, "SUBSET_REPOS", frozenset({"demo-lib"}))
+    justfile = _JUSTFILE.split("# Auth via", maxsplit=1)[0]
+    files = {
+        "pyproject.toml": _PYPROJECT,
+        "justfile": justfile,
+        ".github/workflows/release.yml": None,
+        ".github/workflows/scheduled.yml": None,
+    }
+    assert report.run_census([_snapshot(**files)], _CONTEXT) == []
+
+
+def test_whole_repo_exemption_keeps_only_the_coverage_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(registry.EXEMPTIONS, "demo-lib", registry.CORE_ITEMS - {"coverage-gate"})
+    files = {path: None for path in _COMPLIANT_FILES if path != "pyproject.toml"}
+    findings = report.run_census([_snapshot(**files)], _CONTEXT)
+    assert [f.item for f in findings] == ["coverage-gate"]
+
+
+def test_description_surfaces_compare_three_places() -> None:
+    context = rules.Context(newest_python="3.14", profile_descriptions={"demo-lib": "Something else"})
+    findings = report.run_census([_snapshot()], context)
+    assert [f.item for f in findings] == ["description-surfaces"]
+    assert "profile row" in findings[0].message
+
+
+def test_local_snapshot_without_github_metadata_skips_metadata_rules() -> None:
+    snapshot = RepoSnapshot(name="demo-lib", files=_COMPLIANT_FILES)
+    assert report.run_census([snapshot], rules.Context(newest_python="3.14")) == []
+
+
+def test_shared_checks_workflow_satisfies_ci_and_matrix() -> None:
+    ci = _CI.replace("./.github/workflows/_checks.yml", "modern-python/.github/.github/workflows/checks.yml@main")
+    files = {".github/workflows/ci.yml": ci, ".github/workflows/_checks.yml": None}
+    assert report.run_census([_snapshot(**files)], _CONTEXT) == []
+
+
+def test_newest_cycle_ignores_unreleased_cycles() -> None:
+    payload = [
+        {"cycle": "3.15", "releaseDate": "2026-10-01"},
+        {"cycle": "3.14", "releaseDate": "2025-10-07"},
+        {"cycle": "3.9", "releaseDate": "2020-10-05"},
+    ]
+    assert python_releases.newest_cycle_from_payload(payload, datetime.date(2026, 9, 12)) == "3.14"
+    assert python_releases.newest_cycle_from_payload(payload, datetime.date(2026, 10, 1)) == "3.15"
+
+
+def test_profile_descriptions_parse_real_profile() -> None:
+    descriptions = report.profile_descriptions(pathlib.Path(__file__).parent.parent / "profile" / "README.md")
+    assert descriptions["modern-di"] == "Powerful dependency-injection framework with IoC container and scopes"
+
+
+def test_render_markdown_groups_by_repo() -> None:
+    findings = [report.Finding(repo="b", item="x", message="m1"), report.Finding(repo="a", item="y", message="m2")]
+    text = report.render_markdown(findings, 3)
+    assert text.startswith("2 findings across 2 of 3 repos.")
+    assert text.index("### a") < text.index("### b")
+
+
+def test_gate_in_pytest_addopts_counts_as_a_gate_in_the_wrong_home() -> None:
+    pyproject = _PYPROJECT + '\n[tool.pytest.ini_options]\naddopts = "--cov=. --cov-fail-under=100"\n'
+    justfile = _JUSTFILE.replace(" --cov-fail-under=100", "")
+    findings = report.run_census([_snapshot(**{"pyproject.toml": pyproject, "justfile": justfile})], _CONTEXT)
+    assert {f.item for f in findings} == {"coverage-gate-home"}
+    assert any("addopts" in f.message for f in findings)
+
+
+def test_lowercase_readme_is_found() -> None:
+    files = {"README.md": None, "readme.md": "# demo\n\n[guide](docs/guide.md)\n"}
+    findings = report.run_census([_snapshot(**files)], _CONTEXT)
+    assert [f.item for f in findings] == ["readme-links"]
+    assert "relative link" in findings[0].message

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,7 @@ dev = [
     { name = "fonttools" },
     { name = "pillow" },
     { name = "pytest" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -422,6 +423,7 @@ dev = [
     { name = "fonttools", specifier = ">=4.63.0" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the **census**: the enforcement half of the standard (#88, which this PR is based on). It reads every non-archived org repo through the GitHub API, one tarball per repo, and asserts the standard's core, honouring the exemptions table. One rule per core item; the registry is the machine-readable exemptions table, and tests keep it in sync with `docs/standard.md` (same exempt repos, same canonical paragraphs, same ignore list).

Runs: `just census` (live, marked `census`, deselected from the default `pytest` run) and `just census-report` (Markdown, exit 1 on findings). The workflow runs on pull requests here that touch the standard, the census, or the profile, where findings are informational in the job summary, and every Monday, where a failure files one issue labelled `census` whose body is the current report, refreshed on later failures and closed by hand once clean.

The first real run reports 185 findings across all 27 repos: mostly `ruff-config` (`fix = false`, `target-version` set, dead `G004`, global `S101`), `python-matrix` (no `3.14t`), and `justfile-recipes` (no `test-ci` where the gate lives in pytest `addopts`). `that-depends` shows exactly its one expected finding, the coverage gate. That backlog is the convergence work, not a reason to block this PR; the check on this PR is informational by design.

## Changes

- `census/`: `registry.py` (exemptions, canonical constants), `rules.py` (16 checks), `snapshot.py` (GitHub and local loaders), `python_releases.py` (newest cycle from endoflife.date), `report.py`, `__main__.py`.
- `tests/test_census_rules.py`: 40 offline tests over a synthetic compliant repo, one deviation at a time. `tests/test_census_registry.py`: registry ↔ standard sync. `tests/test_census.py`: the live run.
- `.github/workflows/census.yml`, `.github/scripts/report-census-failure.sh`: PR and weekly runs, tracking issue.
- `justfile`: `census`, `census-report`. `pyproject.toml`: `pyyaml` in `dev`, `census` marker deselected by default.

## Checklist

- [x] Lint and format pass (`ruff`) — this repo has no ruff config; checked by hand with `modern-di`'s config (`select = ["ALL"]`, `INP001` ignored since `tests/` has no `__init__.py`): clean
- [x] Type check passes (`ty`) — `ty check census`: clean
- [x] Tests pass and new behavior is covered — `uv run pytest`: 170 passed; live run against GitHub: 27 repos in ~54 s
- [x] Build succeeds — n/a, not a package
- [x] Repo metadata stays consistent across the three surfaces — untouched
