### PR TITLE
docs(standard): exempt modern-di-arq and modern-di-grpc from the 3.14t matrix entry

### DIFF
--- a/docs/standard.md
+++ b/docs/standard.md
@@ -212,6 +212,8 @@ purpose-first, about 120 characters at most, no trailing period.
 | Repo | Exempt from | Why |
 |---|---|---|
 | `that-depends` | the core as a whole | The org's most-used package and the only repo with steady external contributor traffic; it keeps its own tooling rather than converging. It does adopt the 100 % coverage gate. |
+| `modern-di-arq` | section 6, the `3.14t` matrix entry | Every `arq` release requires `redis[hiredis]<6`, and importing `hiredis` re-enables the GIL ([hiredis-py#229](https://github.com/redis/hiredis-py/issues/229)). Lift when a `hiredis` release declares free-threading support. |
+| `modern-di-grpc` | section 6, the `3.14t` matrix entry | `grpcio` ships no free-threaded wheel and importing `cygrpc` re-enables the GIL ([grpc/grpc#38762](https://github.com/grpc/grpc/issues/38762)). Lift when a `grpcio` release declares free-threading support. |
 
 An exemption is granted by a pull request to this repo that adds the row. Drift that nobody
 recorded is not an exemption.


### PR DESCRIPTION
Both repos cannot keep the GIL disabled on 3.14t because of a dependency, not their own code: every arq release requires redis[hiredis]<6 and hiredis re-enables the GIL on import (redis/hiredis-py#229); grpcio ships no free-threaded wheel and cygrpc re-enables the GIL on import (grpc/grpc#38762). Each row names the upstream release that lifts it.

Refs #91
